### PR TITLE
Added right click melee attack to guns

### DIFF
--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -25,6 +25,7 @@ using Robust.Shared.Random;
 using System.Linq;
 using System.Numerics;
 using Content.Shared.Chat;
+using Content.Shared.Weapons.Ranged.Components;
 
 namespace Content.Server.Weapons.Melee;
 
@@ -58,7 +59,7 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
 
         _damageExamine.AddDamageExamine(args.Message, damageSpec, Loc.GetString("damage-melee"));
 
-        if (damageSpec * component.HeavyDamageBaseModifier != damageSpec)
+        if (damageSpec * component.HeavyDamageBaseModifier != damageSpec && !TryComp<GunComponent>(uid, out var gun)) // Guns don't have a heavy attack
             _damageExamine.AddDamageExamine(args.Message, damageSpec * component.HeavyDamageBaseModifier, Loc.GetString("damage-melee-heavy"));
     }
 

--- a/Content.Shared/Weapons/Melee/Events/MeleeAttemptedEvent.cs
+++ b/Content.Shared/Weapons/Melee/Events/MeleeAttemptedEvent.cs
@@ -1,0 +1,37 @@
+namespace Content.Shared.Weapons.Melee.Events;
+
+/// <summary>
+/// Raised on a melee when someone is attempting to attack with it.
+/// Cancel this event to prevent it from attacking.
+/// </summary>
+[ByRefEvent]
+public record struct MeleeAttemptedEvent
+{
+    /// <summary>
+    /// The user attempting to attack with the weapon.
+    /// </summary>
+    public EntityUid User;
+
+    /// <summary>
+    /// The weapon being used.
+    /// </summary>
+    public EntityUid Used;
+
+    public bool Cancelled { get; private set; }
+
+    /// </summary>
+    /// Prevent the weapon from attacking
+    /// </summary>
+    public void Cancel()
+    {
+        Cancelled = true;
+    }
+
+    /// </summary>
+    /// Allow the weapon to attack again, only use if you know what you are doing
+    /// </summary>
+    public void Uncancel()
+    {
+        Cancelled = false;
+    }
+}

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -62,7 +62,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<MeleeWeaponComponent, HandSelectedEvent>(OnMeleeSelected);
-        SubscribeLocalEvent<MeleeWeaponComponent, ShotAttemptedEvent>(OnMeleeShotAttempted);
+        SubscribeLocalEvent<MeleeWeaponComponent, MeleeAttemptedEvent>(OnMeleeAttempted);
         SubscribeLocalEvent<MeleeWeaponComponent, GunShotEvent>(OnMeleeShot);
         SubscribeLocalEvent<BonusMeleeDamageComponent, GetMeleeDamageEvent>(OnGetBonusMeleeDamage);
         SubscribeLocalEvent<BonusMeleeDamageComponent, GetHeavyDamageModifierEvent>(OnGetBonusHeavyDamageModifier);
@@ -86,7 +86,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 #endif
     }
 
-    private void OnMeleeShotAttempted(EntityUid uid, MeleeWeaponComponent comp, ref ShotAttemptedEvent args)
+    private void OnMeleeAttempted(EntityUid uid, MeleeWeaponComponent comp, ref MeleeAttemptedEvent args)
     {
         if (comp.NextAttack > Timing.CurTime)
             args.Cancel();

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -76,7 +76,7 @@ public abstract partial class SharedGunSystem : EntitySystem
     {
         SubscribeAllEvent<RequestShootEvent>(OnShootRequest);
         SubscribeAllEvent<RequestStopShootEvent>(OnStopShootRequest);
-        SubscribeLocalEvent<GunComponent, MeleeHitEvent>(OnGunMelee);
+        //SubscribeLocalEvent<GunComponent, MeleeHitEvent>(OnGunMelee);
 
         // Ammo providers
         InitializeBallistic();
@@ -110,7 +110,8 @@ public abstract partial class SharedGunSystem : EntitySystem
         RefreshModifiers((gun, gun));
     }
 
-    private void OnGunMelee(EntityUid uid, GunComponent component, MeleeHitEvent args)
+    // Sets the gun cooldown to the melee attack cooldown on attack. Removed since it felt very unintuitive.
+    /*private void OnGunMelee(EntityUid uid, GunComponent component, MeleeHitEvent args)
     {
         if (!TryComp<MeleeWeaponComponent>(uid, out var melee))
             return;
@@ -120,7 +121,7 @@ public abstract partial class SharedGunSystem : EntitySystem
             component.NextFire = melee.NextAttack;
             Dirty(component);
         }
-    }
+    }*/
 
     private void OnShootRequest(RequestShootEvent msg, EntitySessionEventArgs args)
     {

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml
@@ -11,5 +11,16 @@
     - state: animation-icon
       visible: false
       map: [ "empty-icon" ]
+  - type: MeleeWeapon
+    attackRate: 0.7
+    damage:
+      types:
+        Blunt: 7
+    soundHit:
+      collection: GenericHit
+  - type: IncreaseDamageOnWield
+    damage:
+      types:
+        Blunt: 3
   # todo: add itemcomponent with inhandVisuals states using unused texture and animation assets in kinetic_accelerator.rsi
   # todo: add clothingcomponent with clothingVisuals states using unused texture and animations assets in kinetic_accelerator.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -32,6 +32,13 @@
   - type: Appearance
   - type: StaticPrice
     price: 500
+  - type: MeleeWeapon
+    attackRate: 0.7
+    damage:
+      types:
+        Blunt: 10
+    soundHit:
+      collection: GenericHit
 
 - type: entity
   id: BaseWeaponPowerCell
@@ -68,6 +75,13 @@
   - type: ContainerContainer
     containers:
       gun_magazine: !type:ContainerSlot
+  - type: MeleeWeapon
+    attackRate: 0.7
+    damage:
+      types:
+        Blunt: 10
+    soundHit:
+      collection: GenericHit
 
 - type: entity
   id: BaseWeaponBatterySmall
@@ -88,6 +102,11 @@
     slots:
     - Belt
     - suitStorage
+  - type: MeleeWeapon
+    attackRate: 1
+    damage:
+      types:
+        Blunt: 7
 
 - type: entity
   id: BaseWeaponPowerCellSmall

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -60,6 +60,13 @@
     price: 500
   - type: UseDelay
     delay: 1
+  - type: MeleeWeapon
+    attackRate: 0.5
+    damage:
+      types:
+        Blunt: 8
+    soundHit:
+      collection: GenericHit
 
 - type: entity
   name: L6 SAW

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -65,6 +65,12 @@
   - type: Appearance
   - type: StaticPrice
     price: 500
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 7
+    soundHit:
+      collection: GenericHit
 
 - type: entity
   name: viper

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -50,6 +50,12 @@
       path: /Audio/Weapons/Guns/MagIn/revolver_magin.ogg
   - type: StaticPrice
     price: 500
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 7
+    soundHit:
+      collection: GenericHit
 
 - type: entity
   name: Deckard

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -49,6 +49,13 @@
       gun_chamber: !type:ContainerSlot
   - type: StaticPrice
     price: 500
+  - type: MeleeWeapon
+    attackRate: 0.7
+    damage:
+      types:
+        Blunt: 10
+    soundHit:
+      collection: GenericHit
 
 - type: entity
   name: AKMS
@@ -98,6 +105,10 @@
     steps: 1
     zeroVisible: true
   - type: Appearance
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 10
 
 - type: entity
   name: M-90gl

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -20,7 +20,7 @@
     maxAngle: 16
     fireRate: 8
     angleIncrease: 3
-    angleDecay: 16  
+    angleDecay: 16
     selectedMode: FullAuto
     availableModes:
     - SemiAuto
@@ -54,6 +54,13 @@
       gun_chamber: !type:ContainerSlot
   - type: StaticPrice
     price: 500
+  - type: MeleeWeapon
+    attackRate: 0.8
+    damage:
+      types:
+        Blunt: 8
+    soundHit:
+      collection: GenericHit
 
 - type: entity
   name: Atreides
@@ -234,7 +241,7 @@
     minAngle: 1
     maxAngle: 6
     angleIncrease: 1.5
-    angleDecay: 6  
+    angleDecay: 6
     selectedMode: FullAuto
     shotsPerBurst: 5
     availableModes:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -43,6 +43,13 @@
         ents: []
   - type: StaticPrice
     price: 500
+  - type: MeleeWeapon
+    attackRate: 0.7
+    damage:
+      types:
+        Blunt: 10
+    soundHit:
+      collection: GenericHit
 
 - type: entity
   name: Bulldog

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -37,6 +37,13 @@
         ents: []
   - type: StaticPrice
     price: 500
+  - type: MeleeWeapon
+    attackRate: 0.5
+    damage:
+      types:
+        Blunt: 8
+    soundHit:
+      collection: GenericHit
 
 - type: entity
   name: Kardashev-Mosin
@@ -54,6 +61,14 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/sniper.ogg
     fireOnDropChance: 1
+  - type: MeleeWeapon
+    range: 1.4 # AFFIX BAYONETS!
+    damage:
+      types:
+        Piercing: 10
+        Slash: 5
+    soundHit:
+      path: /Audio/Weapons/bladeslice.ogg
 
 - type: entity
   name: Hristov


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

Огнестрельное оружие теперь совместимо с компонентом MeleeWeapon, атаки производятся по нажатию ПКМ в боевом режиме.

Обновлённые характеристики оружия:

Пистолеты - 7 урона, частота атак 1,
ПП - 8 урона, частота атак 0.8,
Дробовики и винтовки - 10 урона, частота атак 0.7.
Винтовка мосина наконец получила свой штык - 10 колющего и 5 режущего урона, частота атак 0.5,
Протокинетик - 7 урона / 10 урона в двух руках. частота атак 0.7.

# Медиа

<!--
Сюда можно вставить различные видео или скриншоты, необходимые для демонстрации работоспособности пулл реквеста.
Если в этом нет необходимости, то весь пункт можно просто удалить.
-->



https://github.com/user-attachments/assets/0a9a7609-7d78-4945-b899-ea8a21f410ec



https://github.com/user-attachments/assets/46968b22-d41d-412e-bcdb-0b2fcdb56c9a



---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl: vanx
- add: Огнестрельное оружие теперь может атаковать вблизи на ПКМ
