### PR TITLE
[Feature] Minor races tweaks

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Player.cs
+++ b/Content.Server/GameTicking/GameTicker.Player.cs
@@ -163,7 +163,9 @@ namespace Content.Server.GameTicking
 
         public HumanoidCharacterProfile GetPlayerProfile(ICommonSession p)
         {
-            return (HumanoidCharacterProfile) _prefsManager.GetPreferences(p.UserId).SelectedCharacter;
+            var profile = (HumanoidCharacterProfile) _prefsManager.GetPreferences(p.UserId).SelectedCharacter;
+            profile.EnsureValid(p, IoCManager.Instance!);
+            return profile;
         }
 
         public void PlayerJoinGame(ICommonSession session, bool silent = false)

--- a/Content.Server/GameTicking/GameTicker.Player.cs
+++ b/Content.Server/GameTicking/GameTicker.Player.cs
@@ -163,9 +163,11 @@ namespace Content.Server.GameTicking
 
         public HumanoidCharacterProfile GetPlayerProfile(ICommonSession p)
         {
+            // White Dream Start
             var profile = (HumanoidCharacterProfile) _prefsManager.GetPreferences(p.UserId).SelectedCharacter;
             profile.EnsureValid(p, IoCManager.Instance!);
             return profile;
+            // White Dream End
         }
 
         public void PlayerJoinGame(ICommonSession session, bool silent = false)

--- a/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
@@ -125,37 +125,37 @@ public sealed partial class SpeciesPrototype : IPrototype
     ///     The minimum height for this species
     /// </summary>
     [DataField]
-    public float MinHeight = 0.9f;
+    public float MinHeight = 0.9f; // White Dream Edit
 
     /// <summary>
     ///     The default height for this species
     /// </summary>
     [DataField]
-    public float DefaultHeight = 1f;
+    public float DefaultHeight = 1f; // White Dream Edit
 
     /// <summary>
     ///     The maximum height for this species
     /// </summary>
     [DataField]
-    public float MaxHeight = 1.1f;
+    public float MaxHeight = 1.1f; // White Dream Edit
 
     /// <summary>
     ///     The minimum width for this species
     /// </summary>
     [DataField]
-    public float MinWidth = 0.9f;
+    public float MinWidth = 0.9f; // White Dream Edit
 
     /// <summary>
     ///     The default width for this species
     /// </summary>
     [DataField]
-    public float DefaultWidth = 1f;
+    public float DefaultWidth = 1f; // White Dream Edit
 
     /// <summary>
     ///     The maximum width for this species
     /// </summary>
     [DataField]
-    public float MaxWidth = 1.1f;
+    public float MaxWidth = 1.1f; // White Dream Edit
 
     /// <summary>
     ///     The average height in centimeters for this species, used to calculate player facing height values in UI elements

--- a/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
@@ -125,7 +125,7 @@ public sealed partial class SpeciesPrototype : IPrototype
     ///     The minimum height for this species
     /// </summary>
     [DataField]
-    public float MinHeight = 0.75f;
+    public float MinHeight = 0.9f;
 
     /// <summary>
     ///     The default height for this species
@@ -137,13 +137,13 @@ public sealed partial class SpeciesPrototype : IPrototype
     ///     The maximum height for this species
     /// </summary>
     [DataField]
-    public float MaxHeight = 1.25f;
+    public float MaxHeight = 1.1f;
 
     /// <summary>
     ///     The minimum width for this species
     /// </summary>
     [DataField]
-    public float MinWidth = 0.7f;
+    public float MinWidth = 0.9f;
 
     /// <summary>
     ///     The default width for this species
@@ -155,7 +155,7 @@ public sealed partial class SpeciesPrototype : IPrototype
     ///     The maximum width for this species
     /// </summary>
     [DataField]
-    public float MaxWidth = 1.3f;
+    public float MaxWidth = 1.1f;
 
     /// <summary>
     ///     The average height in centimeters for this species, used to calculate player facing height values in UI elements

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -532,13 +532,9 @@ namespace Content.Shared.Preferences
                 flavortext = FormattedMessage.RemoveMarkup(FlavorText);
             }
 
-            var height = Height;
-            if (speciesPrototype != null)
-                height = Math.Clamp(Height, speciesPrototype.MinHeight, speciesPrototype.MaxHeight);
+            var height = Math.Clamp(Height, speciesPrototype.MinHeight, speciesPrototype.MaxHeight);
 
-            var width = Width;
-            if (speciesPrototype != null)
-                width = Math.Clamp(Width, speciesPrototype.MinWidth, speciesPrototype.MaxWidth);
+            var width = Math.Clamp(Width, speciesPrototype.MinWidth, speciesPrototype.MaxWidth);
 
             var appearance = HumanoidCharacterAppearance.EnsureValid(Appearance, Species, Sex);
 

--- a/Resources/Locale/ru-RU/species/species.ftl
+++ b/Resources/Locale/ru-RU/species/species.ftl
@@ -6,7 +6,12 @@ species-name-reptilian = Ящер
 species-name-slime = Слаймолюд
 species-name-diona = Диона
 species-name-arachnid = Арахнид
-species-name-skrell = Скрелл
+species-name-arachne = Арахне
 species-name-moth = Моль
 species-name-skeleton = Скелет
+species-name-vox = Вокс
+species-name-ipc = КПБ
+
+# Nyanocode
 species-name-felinid = Фелинид
+species-name-oni = Они

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -123,6 +123,10 @@
         sprite: "Effects/creampie.rsi"
         state: "creampie_arachnid"
         visible: false
+  # White Dream Start - transfer features from Arachne
+  - type: Spider
+  - type: IgnoreSpiderWeb
+  # White Dream End
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
@@ -60,6 +60,8 @@
     - SolCommon
   - type: LightweightDrunk
     boozeStrengthMultiplier: 0.5
+  - type: Stamina
+    critThreshold: 115
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
@@ -60,7 +60,7 @@
     - SolCommon
   - type: LightweightDrunk
     boozeStrengthMultiplier: 0.5
-  - type: Stamina
+  - type: Stamina # White Dream: Make dwarfs a bit more durable.
     critThreshold: 115
 
 - type: entity

--- a/Resources/Prototypes/Nyanotrasen/Species/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Species/Oni.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Oni
   name: species-name-oni
-  roundStart: true
+  roundStart: false # White Dream - Disable roundstart oni
   prototype: MobOni
   dollPrototype: MobOniDummy
   markingLimits: MobOniMarkingLimits

--- a/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
@@ -7,12 +7,12 @@
   markingLimits: MobFelinidMarkingLimits
   dollPrototype: MobFelinidDummy
   skinColoration: HumanToned
-  minHeight: 0.8
-  defaultHeight: 0.8
+  minHeight: 0.8 # White Dream: Changed sizes of all species to be less extreme.
+  defaultHeight: 0.85
   maxHeight: 1
   minWidth: 0.8
   defaultWidth: 0.8
-  maxWidth: 1
+  maxWidth: 1 # White Dream: End of changes
 
 - type: markingPoints
   id: MobFelinidMarkingLimits

--- a/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
@@ -7,12 +7,12 @@
   markingLimits: MobFelinidMarkingLimits
   dollPrototype: MobFelinidDummy
   skinColoration: HumanToned
-  minHeight: 0.65
+  minHeight: 0.8
   defaultHeight: 0.8
-  maxHeight: 1.1
-  minWidth: 0.6
+  maxHeight: 1
+  minWidth: 0.8
   defaultWidth: 0.8
-  maxWidth: 1.15
+  maxWidth: 1
 
 - type: markingPoints
   id: MobFelinidMarkingLimits

--- a/Resources/Prototypes/Species/arachne.yml
+++ b/Resources/Prototypes/Species/arachne.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Arachne
   name: species-name-arachne
-  roundStart: true
+  roundStart: false # White Dream - disable arachne for missing textures.
   prototype: MobArachne
   sprites: MobArachneSprites
   markingLimits: MobArachneMarkingLimits

--- a/Resources/Prototypes/Species/dwarf.yml
+++ b/Resources/Prototypes/Species/dwarf.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Dwarf
   name: species-name-dwarf
-  roundStart: false # DeltaV - Disable dwarf
+  roundStart: true
   prototype: MobDwarf
   sprites: MobHumanSprites
   markingLimits: MobHumanMarkingLimits

--- a/Resources/Prototypes/Species/dwarf.yml
+++ b/Resources/Prototypes/Species/dwarf.yml
@@ -7,9 +7,9 @@
   markingLimits: MobHumanMarkingLimits
   dollPrototype: MobDwarfDummy
   skinColoration: HumanToned
-  minHeight: 0.6
+  minHeight: 0.7
   defaultHeight: 0.8
-  maxHeight: 0.8
-  minWidth: 0.55
+  maxHeight: 0.9
+  minWidth: 0.7
   defaultWidth: 0.8
-  maxWidth: 0.85
+  maxWidth: 0.9

--- a/Resources/Prototypes/Species/dwarf.yml
+++ b/Resources/Prototypes/Species/dwarf.yml
@@ -7,9 +7,9 @@
   markingLimits: MobHumanMarkingLimits
   dollPrototype: MobDwarfDummy
   skinColoration: HumanToned
-  minHeight: 0.7
+  minHeight: 0.7 # White Dream: Changed sizes of all species to be less extreme.
   defaultHeight: 0.8
   maxHeight: 0.9
   minWidth: 0.7
   defaultWidth: 0.8
-  maxWidth: 0.9
+  maxWidth: 0.9 # White Dream: End of changes

--- a/Resources/Prototypes/Species/harpy.yml
+++ b/Resources/Prototypes/Species/harpy.yml
@@ -7,12 +7,12 @@
   markingLimits: MobHarpyMarkingLimits
   dollPrototype: MobHarpyDummy
   skinColoration: HumanToned
-  minHeight: 0.8
-  defaultHeight: 0.8
+  minHeight: 0.8 # White Dream: Changed sizes of all species to be less extreme.
+  defaultHeight: 0.85
   maxHeight: 1
   minWidth: 0.8
   defaultWidth: 0.8
-  maxWidth: 1
+  maxWidth: 1 # White Dream: End of changes
 
 - type: speciesBaseSprites
   id: MobHarpySprites

--- a/Resources/Prototypes/Species/harpy.yml
+++ b/Resources/Prototypes/Species/harpy.yml
@@ -7,12 +7,12 @@
   markingLimits: MobHarpyMarkingLimits
   dollPrototype: MobHarpyDummy
   skinColoration: HumanToned
-  minHeight: 0.6
+  minHeight: 0.8
   defaultHeight: 0.8
-  maxHeight: 1.1
-  minWidth: 0.55
+  maxHeight: 1
+  minWidth: 0.8
   defaultWidth: 0.8
-  maxWidth: 1.15
+  maxWidth: 1
 
 - type: speciesBaseSprites
   id: MobHarpySprites

--- a/Resources/Prototypes/Species/reptilian.yml
+++ b/Resources/Prototypes/Species/reptilian.yml
@@ -11,12 +11,12 @@
   maleFirstNames: names_reptilian_male
   femaleFirstNames: names_reptilian_female
   naming: FirstDashFirst
-  minHeight: 0.7
-  defaultHeight: 0.95
-  maxHeight: 1.25
-  minWidth: 0.65
-  defaultWidth: 0.95
-  maxWidth: 1.3
+  minHeight: 0.9
+  defaultHeight: 1.1
+  maxHeight: 1.2
+  minWidth: 0.9
+  defaultWidth: 1.1
+  maxWidth: 1.2
 
 - type: speciesBaseSprites
   id: MobReptilianSprites

--- a/Resources/Prototypes/Species/reptilian.yml
+++ b/Resources/Prototypes/Species/reptilian.yml
@@ -11,12 +11,12 @@
   maleFirstNames: names_reptilian_male
   femaleFirstNames: names_reptilian_female
   naming: FirstDashFirst
-  minHeight: 0.9
+  minHeight: 0.9 # White Dream: Changed sizes of all species to be less extreme.
   defaultHeight: 1.1
   maxHeight: 1.2
   minWidth: 0.9
   defaultWidth: 1.1
-  maxWidth: 1.2
+  maxWidth: 1.2 # White Dream: End of changes.
 
 - type: speciesBaseSprites
   id: MobReptilianSprites


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

Описание.

---

# Изменения


:cl:
- add: Reintroduced dwarfs / Возвращены дворфы в игру. Лучше переносят алкоголь и имеют чуть больше выносливости, чем остальные расы.
- tweak: Arachnids now have action to place spider web and no longer slowed down by it / Арахниды получили возможность ставить паутину и не замедляться в ней.
- tweak: Most races min/max/default height and width was rebalanced. Now they go mostly +-10% from default / Параметры роста/ширины многих раз были изменены. Теперь они могут (в большинстве случаев) изменяться на максимум +-10% от стандартного значения.
- remove: Removed arachne from roundstart species pool / Арахне были удалены из стартового набора рас.
- remove: Removed oni from roundstart species pool / Они были удалены из стартового набора рас.
