### PR TITLE
Disable Quick Swap for Item Slots by Default

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -410,6 +410,12 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> AllowSlotQuickSwap =
             CVarDef.Create("game.slot_quick_swap", false, CVar.REPLICATED);
 
+        /// <summary>
+        ///     Whether item slots, such as power cell slots or AME fuel cell slots, should support quick swap if it is not otherwise specified in their YAML prototype.
+        /// </summary>
+        public static readonly CVarDef<bool> AllowSlotQuickSwap =
+            CVarDef.Create("game.slot_quick_swap", false, CVar.REPLICATED);
+
 #if EXCEPTION_TOLERANCE
         /// <summary>
         ///     Amount of times round start must fail before the server is shut down.

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -410,11 +410,6 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> AllowSlotQuickSwap =
             CVarDef.Create("game.slot_quick_swap", false, CVar.REPLICATED);
 
-        /// <summary>
-        ///     Whether item slots, such as power cell slots or AME fuel cell slots, should support quick swap if it is not otherwise specified in their YAML prototype.
-        /// </summary>
-        public static readonly CVarDef<bool> AllowSlotQuickSwap =
-            CVarDef.Create("game.slot_quick_swap", false, CVar.REPLICATED);
 
 #if EXCEPTION_TOLERANCE
         /// <summary>

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
@@ -214,6 +214,7 @@ namespace Content.Shared.Containers.ItemSlots
 
         /// <summary>
         ///     If the user interacts with an entity with an already-filled item slot, should they attempt to swap out the item?
+        ///     If set to null, will be deduced based on the relevant config variable.
         /// </summary>
         /// <remarks>
         ///     Useful for things like chem dispensers, but undesirable for things like the ID card console, where you
@@ -221,7 +222,7 @@ namespace Content.Shared.Containers.ItemSlots
         /// </remarks>
         [DataField]
         [Access(typeof(ItemSlotsSystem), Other = AccessPermissions.ReadWriteExecute)]
-        public bool Swap = true;
+        public bool? Swap = null;
 
         public string? ID => ContainerSlot?.ID;
 

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Logs;
+using Content.Shared.CCVar;
 using Content.Shared.Database;
 using Content.Shared.Destructible;
 using Content.Shared.Hands.Components;
@@ -10,6 +11,7 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Configuration;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Utility;
@@ -27,10 +29,13 @@ namespace Content.Shared.Containers.ItemSlots
     {
         [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
         [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
+        [Dependency] private readonly IConfigurationManager _config = default!;
         [Dependency] private readonly SharedContainerSystem _containers = default!;
         [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
         [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
         [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
+
+        private bool _defaultQuickSwap;
 
         public override void Initialize()
         {
@@ -53,6 +58,8 @@ namespace Content.Shared.Containers.ItemSlots
             SubscribeLocalEvent<ItemSlotsComponent, ComponentHandleState>(HandleItemSlotsState);
 
             SubscribeLocalEvent<ItemSlotsComponent, ItemSlotButtonPressedEvent>(HandleButtonPressed);
+
+            _config.OnValueChanged(CCVars.AllowSlotQuickSwap, b => _defaultQuickSwap = b, true);
         }
 
         #region ComponentManagement
@@ -202,7 +209,7 @@ namespace Content.Shared.Containers.ItemSlots
                 if (!slot.InsertOnInteract)
                     continue;
 
-                if (!CanInsert(uid, args.Used, args.User, slot, swap: slot.Swap, popup: args.User))
+                if (!CanInsert(uid, args.Used, args.User, slot, swap: slot.Swap ?? _defaultQuickSwap, popup: args.User))
                     continue;
 
                 // Drop the held item onto the floor. Return if the user cannot drop.


### PR DESCRIPTION
From https://github.com/Simple-Station/Einstein-Engines/pull/856/

:cl: Mnemotechnician, vanx
- tweak: Предметы больше не меняются местами при попытке вставить их в занятый слот (магазин в пистолет, карту в КПК, топливо в ДАМ и т.п.)