### PR TITLE
Alt-Z

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
@@ -149,7 +149,10 @@ public abstract partial class SharedHandsSystem : EntitySystem
             return false;
 
         if (altInteract)
-            return _interactionSystem.AltInteract(uid, held);
+            if(hand == handsComp.ActiveHand)    // WD EDIT START
+                return _interactionSystem.ActiveHandAltInteract(uid, held) || _interactionSystem.AltInteract(uid, held); // todo: should these be merged into one method?
+            else                                // WD EDIT END
+                return _interactionSystem.AltInteract(uid, held);
         else
             return _interactionSystem.UseInHandInteraction(uid, held);
     }

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -1090,7 +1090,7 @@ namespace Content.Shared.Interaction
         public bool AltInteract(EntityUid user, EntityUid target)
         {
             // Get list of alt-interact verbs
-            var verbs = _verbSystem.GetLocalVerbs(target, user, typeof(AlternativeVerb));
+            var verbs = _verbSystem.GetLocalVerbs(target, user, typeof(AlternativeVerb)).Where(verb => ((AlternativeVerb) verb).InActiveHandOnly == false); // WD EDIT
 
             if (!verbs.Any())
                 return false;
@@ -1098,6 +1098,24 @@ namespace Content.Shared.Interaction
             _verbSystem.ExecuteVerb(verbs.First(), user, target);
             return true;
         }
+
+        // WD EDIT START
+        /// <summary>
+        ///     Very alternative interactions on an entity.
+        /// </summary>
+        /// <returns>True if the interaction was handled, false otherwise.</returns>
+        public bool ActiveHandAltInteract(EntityUid user, EntityUid target)
+        {
+            // Get list of alt-interact verbs
+            var verbs = _verbSystem.GetLocalVerbs(target, user, typeof(AlternativeVerb)).Where(verb => ((AlternativeVerb)verb).InActiveHandOnly == true);
+
+            if (!verbs.Any())
+                return false;
+
+            _verbSystem.ExecuteVerb(verbs.First(), user, target);
+            return true;
+        }
+        // WD EDIT END
         #endregion
 
         public void DroppedInteraction(EntityUid user, EntityUid item)

--- a/Content.Shared/Verbs/Verb.cs
+++ b/Content.Shared/Verbs/Verb.cs
@@ -310,6 +310,17 @@ namespace Content.Shared.Verbs
     {
         public override int TypePriority => 2;
         public new static string DefaultTextStyleClass = "AlternativeVerb";
+        // WD EDIT START
+        /// <summary>
+        /// If true, this verb can only be triggered by alt-interacting (alt-Z) with the parent item
+        /// while holding it in the active hand, or via context menu. The latter does not require holding in active hand.
+        /// </summary>
+        /// <remarks>
+        /// On alt-Z, if item returns no <see cref="AlternativeVerb"/> with <see cref="InActiveHandOnly"/> being true, other <see cref="AlternativeVerb"/>s will be considered.
+        /// This is not true for the reverse: alt-clicking an item not in your main hand will not proc an <see cref="AlternativeVerb"/> if it's <see cref="InActiveHandOnly"/> is true.
+        /// </remarks>
+        public bool InActiveHandOnly = false; // todo: better name?
+        // WD EDIT END
         public override bool DefaultDoContactInteraction => true;
 
         public AlternativeVerb() : base()

--- a/Content.Shared/Wieldable/Components/WieldableComponent.cs
+++ b/Content.Shared/Wieldable/Components/WieldableComponent.cs
@@ -39,8 +39,9 @@ public sealed partial class WieldableComponent : Component
     public string? OldInhandPrefix = null;
     // WD EDIT START
     /// <summary>
-    /// Requires item to be alt-used (alt-Z / alt-click in active hand) to be wielded.
+    /// Requires item to be alt-used in hand (alt-Z / alt-click in active hand) to be wielded.
     /// </summary>
+    [DataField]
     public bool AltUseInHand = false;
     // WD EDIT END
 }

--- a/Content.Shared/Wieldable/Components/WieldableComponent.cs
+++ b/Content.Shared/Wieldable/Components/WieldableComponent.cs
@@ -37,6 +37,12 @@ public sealed partial class WieldableComponent : Component
     public string? WieldedInhandPrefix = "wielded";
 
     public string? OldInhandPrefix = null;
+    // WD EDIT START
+    /// <summary>
+    /// Requires item to be alt-used (alt-Z / alt-click in active hand) to be wielded.
+    /// </summary>
+    public bool AltUseInHand = false;
+    // WD EDIT END
 }
 
 [Serializable, NetSerializable]


### PR DESCRIPTION
# Описание PR
Альт-клик по предмету в активной руке теперь отличается от альт-клика по предмету в неактивной руке или на полу.

# Медиа
<details><summary></summary>
<p>

[ass.webm](https://github.com/user-attachments/assets/a38ecc36-9ddc-4333-88cb-83b36ea9b4be)

Взаимодействие с предметом в мире у меня назначено на F, если что. (дефолт E)

---
</p>
</details>

# Матчасть

* В `AlternativeVerb` теперь есть флажок `InActiveHandOnly`, дефолт `false`. Если он выставлен на `true`, то данный верб можно прокнуть только через контекстное меню (как и все альтвербы), либо через альт. использование в руке, см. описание ПРа.
* * Альт-З по-прежднему может прокать все альтвербы, просто в итоге приоритет уходит альвербам с `InActiveHandOnly==true`.

* В `WieldableComponent` теперь есть флажок `AltUseInHand`, дефолт `false`. Если он выставлен на `true`, то чтобы взять предмет в обе руки, нужно нажать альт-z. Если он `false`, то всё работает, как раньше. Для топоров и прочего можно оставить, как есть, для огнестрела фичу лучше включить.

В прототипах:

```
  components:
   ...
    Wieldable:
      AltUseInHand = true
```

# Зачем

Мне не понравилось, что у оружия два разных действия (дёрнуть затвор и взять в две руки) были назначены на одну кнопку. Настолько сильно, что мне сказали это фиксить.

# Изменения

:cl:
- tweak: Альтернативное использование предметов в *активной руке* теперь может быть отличным от альтернативного использования предмета на полу/в неактивной руке. Ключевое слово - (*может*).