### PR TITLE
mom get the camera

### DIFF
--- a/Content.Shared/CombatMode/CombatModeComponent.cs
+++ b/Content.Shared/CombatMode/CombatModeComponent.cs
@@ -48,5 +48,18 @@ namespace Content.Shared.CombatMode
         /// </summary>
         [DataField, AutoNetworkedField]
         public bool ToggleMouseRotator = true;
+
+
+        /// <summary>
+        ///     If true, sets <see cref="MouseRotatorComponent.AngleTolerance"/> to 1 degree and <see cref="MouseRotatorComponent.Simple4DirMode"/>
+        ///     to false when the owner enters combatmode. This is currently being tested as of 06.12.24,
+        ///     so a simple bool switch should suffice.
+        ///     Leaving AutoNetworking just in case shitmins need to disable it for someone. Will only take effect when re-enabling combat mode.
+        /// </summary>
+        /// <remarks>
+        ///     No effect if <see cref="ToggleMouseRotator"/> is false.
+        /// </remarks>
+        [DataField, AutoNetworkedField]
+        public bool smoothRotation = true;
     }
 }

--- a/Content.Shared/CombatMode/CombatModeComponent.cs
+++ b/Content.Shared/CombatMode/CombatModeComponent.cs
@@ -49,7 +49,7 @@ namespace Content.Shared.CombatMode
         [DataField, AutoNetworkedField]
         public bool ToggleMouseRotator = true;
 
-
+        // WD EDIT START
         /// <summary>
         ///     If true, sets <see cref="MouseRotatorComponent.AngleTolerance"/> to 1 degree and <see cref="MouseRotatorComponent.Simple4DirMode"/>
         ///     to false when the owner enters combatmode. This is currently being tested as of 06.12.24,
@@ -61,5 +61,6 @@ namespace Content.Shared.CombatMode
         /// </remarks>
         [DataField, AutoNetworkedField]
         public bool SmoothRotation = true;
+        // WD EDIT END
     }
 }

--- a/Content.Shared/CombatMode/CombatModeComponent.cs
+++ b/Content.Shared/CombatMode/CombatModeComponent.cs
@@ -60,6 +60,6 @@ namespace Content.Shared.CombatMode
         ///     No effect if <see cref="ToggleMouseRotator"/> is false.
         /// </remarks>
         [DataField, AutoNetworkedField]
-        public bool smoothRotation = true;
+        public bool SmoothRotation = true;
     }
 }

--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -92,7 +92,12 @@ public abstract class SharedCombatModeSystem : EntitySystem
     {
         if (value)
         {
-            EnsureComp<MouseRotatorComponent>(uid);
+            var rot = EnsureComp<MouseRotatorComponent>(uid);
+            if (TryComp<CombatModeComponent>(uid, out var comp) && comp.smoothRotation) // no idea under which (intended) circumstances this can fail (if any), so i'll avoid Comp<>().
+            {
+                rot.AngleTolerance = Angle.FromDegrees(1); // arbitrary
+                rot.Simple4DirMode = false;
+            }
             EnsureComp<NoRotateOnMoveComponent>(uid);
         }
         else

--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -93,7 +93,7 @@ public abstract class SharedCombatModeSystem : EntitySystem
         if (value)
         {
             var rot = EnsureComp<MouseRotatorComponent>(uid);
-            if (TryComp<CombatModeComponent>(uid, out var comp) && comp.smoothRotation) // no idea under which (intended) circumstances this can fail (if any), so i'll avoid Comp<>().
+            if (TryComp<CombatModeComponent>(uid, out var comp) && comp.SmoothRotation) // no idea under which (intended) circumstances this can fail (if any), so i'll avoid Comp<>().
             {
                 rot.AngleTolerance = Angle.FromDegrees(1); // arbitrary
                 rot.Simple4DirMode = false;

--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -93,11 +93,13 @@ public abstract class SharedCombatModeSystem : EntitySystem
         if (value)
         {
             var rot = EnsureComp<MouseRotatorComponent>(uid);
+            // WD EDIT START
             if (TryComp<CombatModeComponent>(uid, out var comp) && comp.SmoothRotation) // no idea under which (intended) circumstances this can fail (if any), so i'll avoid Comp<>().
             {
                 rot.AngleTolerance = Angle.FromDegrees(1); // arbitrary
                 rot.Simple4DirMode = false;
             }
+            // WD EDIT END
             EnsureComp<NoRotateOnMoveComponent>(uid);
         }
         else

--- a/Content.Shared/MouseRotator/MouseRotatorComponent.cs
+++ b/Content.Shared/MouseRotator/MouseRotatorComponent.cs
@@ -1,4 +1,4 @@
-﻿using System.Numerics;
+using System.Numerics;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 


### PR DESCRIPTION
# Описание PR
[smoothrot.webm](https://github.com/user-attachments/assets/9220cdad-9437-4bdb-8a80-25ca0b94cc23)

Чтобы выключить в прототипе:
`smoothRotation = false` в `CombatMode`. Дефолт пока что true.

:cl:
- add: В тестовом режиме: персонажи теперь вращаются на все полные, красивые 360°. Ну, кроме спрайтиков. Спрайтики всё ещё двухмерные, с четырьмя направлениями. Зато какие теперь классные фонарики!
