### PR TITLE
[Tweak] Flying tiles no longer embed on hit

### DIFF
--- a/Resources/Locale/ru-RU/prototypes/entities/objects/misc/tiles.ftl
+++ b/Resources/Locale/ru-RU/prototypes/entities/objects/misc/tiles.ftl
@@ -1,5 +1,5 @@
 ent-FloorTileItemBase = { ent-BaseItem }
-    .desc = Может послужить неплохим метательным оружием.
+    .desc = Может больно прилететь по голове.
     .suffix = { "" }
 ent-FloorTileItemSteel = стальная плитка
     .desc = { ent-FloorTileItemBase.desc }

--- a/Resources/Prototypes/Entities/Objects/Misc/tiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/tiles.yml
@@ -9,7 +9,7 @@
   - type: Item
     sprite: Objects/Tiles/tile.rsi
     size: Normal
-  - type: EmbeddableProjectile
+  # - type: EmbeddableProjectile # WWDP no embedding
   - type: DamageOtherOnHit
     damage:
       types:


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

Плитки пола больше не embeddable, потому что это было раздражающе да и выглядело крайне глупо.

---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl: vanx
- tweak: Летящие плитки пола больше не застревают в телах и стенах
