### PR TITLE
[Twe4k] No roundst4rt CC roles

### DIFF
--- a/Resources/Prototypes/Maps/arena.yml
+++ b/Resources/Prototypes/Maps/arena.yml
@@ -24,9 +24,9 @@
 #             Librarian: [ 1, 1 ]
 #           #command
 #             Captain: [ 1, 1 ]
-#             BlueshieldOfficer: [ 1, 1]
-#             NanotrasenRepresentative: [ 1, 1 ]
-#             Magistrate: [ 1, 1 ]
+#             BlueshieldOfficer: [ 0, 0 ] # WWDP no roundstart CC roles
+#             NanotrasenRepresentative: [ 0, 0 ] # WWDP no roundstart CC roles
+#             Magistrate: [ 0, 0 ] # WWDP no roundstart CC roles
 #             AdministrativeAssistant: [ 1, 1 ]
 #           #engineering
 #             AtmosphericTechnician: [ 1, 2 ]

--- a/Resources/Prototypes/Maps/asterisk.yml
+++ b/Resources/Prototypes/Maps/asterisk.yml
@@ -24,9 +24,9 @@
 #           availableJobs:
 #           #service
 #             Captain: [ 1, 1 ]
-#             BlueshieldOfficer: [ 1, 1]
-#             NanotrasenRepresentative: [ 1, 1 ]
-#             Magistrate: [ 1, 1 ]
+#             BlueshieldOfficer: [ 0, 0 ] # WWDP no roundstart CC roles
+#             NanotrasenRepresentative: [ 0, 0 ] # WWDP no roundstart CC roles
+#             Magistrate: [ 0, 0 ] # WWDP no roundstart CC roles
 #             AdministrativeAssistant: [ 1, 1 ]
 #             HeadOfPersonnel: [ 1, 1 ]
 #             Bartender: [ 1, 2 ]

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -19,8 +19,8 @@
           availableJobs:
             #command
             Captain: [ 1, 1 ]
-            NanotrasenRepresentative: [ 1, 1 ]
-            BlueshieldOfficer: [ 1, 1 ]
+            NanotrasenRepresentative: [ 0, 0 ] # WWDP no roundstart CC roles
+            BlueshieldOfficer: [ 0, 0 ] # WWDP no roundstart CC roles
             AdministrativeAssistant: [ 1, 1 ]
             #service
             HeadOfPersonnel: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -19,11 +19,11 @@
           availableJobs:
             #service
             Captain: [ 1, 1 ]
-            NanotrasenRepresentative: [ 1, 1 ]
-            BlueshieldOfficer: [ 1, 1 ]
+            NanotrasenRepresentative: [ 0, 0 ] # WWDP no roundstart CC roles
+            BlueshieldOfficer: [ 0, 0 ] # WWDP no roundstart CC roles
             HeadOfPersonnel: [ 1, 1 ]
             AdministrativeAssistant: [ 1, 1 ]
-            Magistrate: [ 1, 1 ]
+            Magistrate: [ 0, 0 ] # WWDP no roundstart CC roles
             Bartender: [ 2, 2 ]
             Botanist: [ 3, 3 ]
             Chef: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -25,9 +25,9 @@
             Chef: [ 1, 3 ]
             Janitor: [ 2, 4 ]
             Captain: [ 1, 1 ]
-            BlueshieldOfficer: [ 1, 1]
-            NanotrasenRepresentative: [ 1, 1 ]
-            Magistrate: [ 1, 1 ]
+            BlueshieldOfficer: [ 0, 0 ] # WWDP no roundstart CC roles
+            NanotrasenRepresentative: [ 0, 0 ] # WWDP no roundstart CC roles
+            Magistrate: [ 0, 0 ] # WWDP no roundstart CC roles
             AdministrativeAssistant: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             ServiceWorker: [ 3, 6 ]

--- a/Resources/Prototypes/Maps/edge.yml
+++ b/Resources/Prototypes/Maps/edge.yml
@@ -21,9 +21,9 @@
 #           availableJobs:
 #           #service
 #             Captain: [ 1, 1 ]
-#             BlueshieldOfficer: [ 1, 1]
-#             NanotrasenRepresentative: [ 1, 1 ]
-#             Magistrate: [ 1, 1 ]
+#             BlueshieldOfficer: [ 0, 0 ] # WWDP no roundstart CC roles
+#             NanotrasenRepresentative: [ 0, 0 ] # WWDP no roundstart CC roles
+#             Magistrate: [ 0, 0 ] # WWDP no roundstart CC roles
 #             AdministrativeAssistant: [ 1, 1 ]
 #             HeadOfPersonnel: [ 1, 1 ]
 #             Bartender: [ 1, 2 ]

--- a/Resources/Prototypes/Maps/europa.yml
+++ b/Resources/Prototypes/Maps/europa.yml
@@ -19,9 +19,9 @@
 #           availableJobs:
 #           #service
 #             Captain: [ 1, 1 ]
-#             BlueshieldOfficer: [ 1, 1]
-#             NanotrasenRepresentative: [ 1, 1 ]
-#             Magistrate: [ 1, 1 ]
+#             BlueshieldOfficer: [ 0, 0 ] # WWDP no roundstart CC roles
+#             NanotrasenRepresentative: [ 0, 0 ] # WWDP no roundstart CC roles
+#             Magistrate: [ 0, 0 ] # WWDP no roundstart CC roles
 #             AdministrativeAssistant: [ 1, 1 ]
 #             HeadOfPersonnel: [ 1, 1 ]
 #             Bartender: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/gaxstation.yml
+++ b/Resources/Prototypes/Maps/gaxstation.yml
@@ -20,9 +20,9 @@
           availableJobs:
             #service
             Captain: [ 1, 1 ]
-            NanotrasenRepresentative: [ 1, 1 ]
-            BlueshieldOfficer: [ 1, 1 ]
-            Magistrate: [ 1, 1 ]
+            NanotrasenRepresentative: [ 0, 0 ] # WWDP no roundstart CC roles
+            BlueshieldOfficer: [ 0, 0 ] # WWDP no roundstart CC roles
+            Magistrate: [ 0, 0 ] # WWDP no roundstart CC roles
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 1, 1 ]
             Botanist: [3 , 3 ]

--- a/Resources/Prototypes/Maps/glacier.yml
+++ b/Resources/Prototypes/Maps/glacier.yml
@@ -23,9 +23,9 @@
         availableJobs:
           Passenger: [ -1, -1 ]
           Captain: [ 1, 1 ]
-          BlueshieldOfficer: [ 1, 1]
-          NanotrasenRepresentative: [ 1, 1 ]
-          Magistrate: [ 1, 1 ]
+          BlueshieldOfficer: [ 0, 0 ] # WWDP no roundstart CC roles
+          NanotrasenRepresentative: [ 0, 0 ] # WWDP no roundstart CC roles
+          Magistrate: [ 0, 0 ] # WWDP no roundstart CC roles
           AdministrativeAssistant: [ 1, 1 ]
         #service
           HeadOfPersonnel: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/hammurabi.yml
+++ b/Resources/Prototypes/Maps/hammurabi.yml
@@ -23,9 +23,9 @@
 #             Librarian: [ 1, 1 ]
 #           #command
 #             Captain: [ 1, 1 ]
-#             BlueshieldOfficer: [ 1, 1]
-#             NanotrasenRepresentative: [ 1, 1 ]
-#             Magistrate: [ 1, 1 ]
+#             BlueshieldOfficer: [ 0, 0 ] # WWDP no roundstart CC roles
+#             NanotrasenRepresentative: [ 0, 0 ] # WWDP no roundstart CC roles
+#             Magistrate: [ 0, 0 ] # WWDP no roundstart CC roles
 #             AdministrativeAssistant: [ 1, 1 ]
 #           #engineering
 #             AtmosphericTechnician: [ 2, 3 ]

--- a/Resources/Prototypes/Maps/hive.yml
+++ b/Resources/Prototypes/Maps/hive.yml
@@ -24,9 +24,9 @@
 #             Librarian: [ 1, 1 ]
 #           #command
 #             Captain: [ 1, 1 ]
-#             BlueshieldOfficer: [ 1, 1]
-#             NanotrasenRepresentative: [ 1, 1 ]
-#             Magistrate: [ 1, 1 ]
+#             BlueshieldOfficer: [ 0, 0 ] # WWDP no roundstart CC roles
+#             NanotrasenRepresentative: [ 0, 0 ] # WWDP no roundstart CC roles
+#             Magistrate: [ 0, 0 ] # WWDP no roundstart CC roles
 #             AdministrativeAssistant: [ 1, 1 ]
 #           #engineering
 #             AtmosphericTechnician: [ 1, 2 ]

--- a/Resources/Prototypes/Maps/lambda.yml
+++ b/Resources/Prototypes/Maps/lambda.yml
@@ -22,9 +22,9 @@
             #service
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            NanotrasenRepresentative: [ 1, 1 ]
-            BlueshieldOfficer: [ 1, 1 ]
-            Magistrate: [ 1, 1 ]
+            NanotrasenRepresentative: [ 0, 0 ] # WWDP no roundstart CC roles
+            BlueshieldOfficer: [ 0, 0 ] # WWDP no roundstart CC roles
+            Magistrate: [ 0, 0 ] # WWDP no roundstart CC roles
             AdministrativeAssistant: [ 1, 1 ]
             Bartender: [ 2, 2 ]
             Botanist: [ 2 , 3 ]

--- a/Resources/Prototypes/Maps/lighthouse.yml
+++ b/Resources/Prototypes/Maps/lighthouse.yml
@@ -21,9 +21,9 @@
         availableJobs:
         #service
           Captain: [ 1, 1 ]
-          BlueshieldOfficer: [ 1, 1]
-          NanotrasenRepresentative: [ 1, 1 ]
-          Magistrate: [ 1, 1 ]
+          BlueshieldOfficer: [ 0, 0 ] # WWDP no roundstart CC roles
+          NanotrasenRepresentative: [ 0, 0 ] # WWDP no roundstart CC roles
+          Magistrate: [ 0, 0 ] # WWDP no roundstart CC roles
           AdministrativeAssistant: [ 1, 1 ]
           HeadOfPersonnel: [ 1, 1 ]
           Bartender: [ 1, 2 ]

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -19,9 +19,9 @@
           availableJobs:
             #service
             Captain: [ 1, 1 ]
-            BlueshieldOfficer: [ 1, 1]
-            NanotrasenRepresentative: [ 1, 1 ]
-            Magistrate: [ 1, 1 ]
+            BlueshieldOfficer: [ 0, 0 ] # WWDP no roundstart CC roles
+            NanotrasenRepresentative: [ 0, 0 ] # WWDP no roundstart CC roles
+            Magistrate: [ 0, 0 ] # WWDP no roundstart CC roles
             AdministrativeAssistant: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/pebble.yml
+++ b/Resources/Prototypes/Maps/pebble.yml
@@ -24,9 +24,9 @@
           availableJobs:
           #service
             Captain: [ 1, 1 ]
-            BlueshieldOfficer: [ 1, 1]
-            NanotrasenRepresentative: [ 1, 1 ]
-            Magistrate: [ 1, 1 ]
+            BlueshieldOfficer: [ 0, 0 ] # WWDP no roundstart CC roles
+            NanotrasenRepresentative: [ 0, 0 ] # WWDP no roundstart CC roles
+            Magistrate: [ 0, 0 ] # WWDP no roundstart CC roles
             AdministrativeAssistant: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 1, 2 ]

--- a/Resources/Prototypes/Maps/radstation.yml
+++ b/Resources/Prototypes/Maps/radstation.yml
@@ -20,9 +20,9 @@
           availableJobs:
             #service
             Captain: [ 1, 1 ]
-            BlueshieldOfficer: [ 1, 1]
-            NanotrasenRepresentative: [ 1, 1 ]
-            Magistrate: [ 1, 1 ]
+            BlueshieldOfficer: [ 0, 0 ] # WWDP no roundstart CC roles
+            NanotrasenRepresentative: [ 0, 0 ] # WWDP no roundstart CC roles
+            Magistrate: [ 0, 0 ] # WWDP no roundstart CC roles
             AdministrativeAssistant: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -22,9 +22,9 @@
           availableJobs:
             #service
             Captain: [ 1, 1 ]
-            BlueshieldOfficer: [ 1, 1]
-            NanotrasenRepresentative: [ 1, 1 ]
-            Magistrate: [ 1, 1 ]
+            BlueshieldOfficer: [ 0, 0 ] # WWDP no roundstart CC roles
+            NanotrasenRepresentative: [ 0, 0 ] # WWDP no roundstart CC roles
+            Magistrate: [ 0, 0 ] # WWDP no roundstart CC roles
             AdministrativeAssistant: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 1, 2 ]

--- a/Resources/Prototypes/Maps/shoukou.yml
+++ b/Resources/Prototypes/Maps/shoukou.yml
@@ -33,9 +33,9 @@
             Musician: [ 1, 1]
             Mime: [ 1, 1 ]
             Captain: [ 1, 1 ]
-            BlueshieldOfficer: [ 1, 1]
-            NanotrasenRepresentative: [ 1, 1 ]
-            Magistrate: [ 1, 1 ]
+            BlueshieldOfficer: [ 0, 0 ] # WWDP no roundstart CC roles
+            NanotrasenRepresentative: [ 0, 0 ] # WWDP no roundstart CC roles
+            Magistrate: [ 0, 0 ] # WWDP no roundstart CC roles
             AdministrativeAssistant: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
           #Engineering

--- a/Resources/Prototypes/Maps/submarine.yml
+++ b/Resources/Prototypes/Maps/submarine.yml
@@ -23,9 +23,9 @@
 #             Librarian: [ 1, 1 ]
 #           #command
 #             Captain: [ 1, 1 ]
-#             BlueshieldOfficer: [ 1, 1]
-#             NanotrasenRepresentative: [ 1, 1 ]
-#             Magistrate: [ 1, 1 ]
+#             BlueshieldOfficer: [ 0, 0 ] # WWDP no roundstart CC roles
+#             NanotrasenRepresentative: [ 0, 0 ] # WWDP no roundstart CC roles
+#             Magistrate: [ 0, 0 ] # WWDP no roundstart CC roles
 #             AdministrativeAssistant: [ 1, 1 ]
 #           #engineering
 #             AtmosphericTechnician: [ 2, 4 ]

--- a/Resources/Prototypes/Maps/tortuga.yml
+++ b/Resources/Prototypes/Maps/tortuga.yml
@@ -23,9 +23,9 @@
 #             Librarian: [ 1, 1 ]
 #           #command
 #             Captain: [ 1, 1 ]
-#             BlueshieldOfficer: [ 1, 1]
-#             NanotrasenRepresentative: [ 1, 1 ]
-#             Magistrate: [ 1, 1 ]
+#             BlueshieldOfficer: [ 0, 0 ] # WWDP no roundstart CC roles
+#             NanotrasenRepresentative: [ 0, 0 ] # WWDP no roundstart CC roles
+#             Magistrate: [ 0, 0 ] # WWDP no roundstart CC roles
 #             AdministrativeAssistant: [ 1, 1 ]
 #           #engineering
 #             AtmosphericTechnician: [ 2, 3 ]


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

Кол-во слотов на роли представителя НТ, магистрата и синего shitа установлено на 0. 
Роли не убраны чтобы на них действовала бюрократическая ошибка (и чтобы про них совсем не забыли).

Слоты можно добавить педалями вручную, используя команду `entities with StationJobs jobs:job NanotrasenRepresentative jobs:adjust 1`

![изображение](https://github.com/user-attachments/assets/db3770f6-6b45-4652-bb04-d00ad49137f4)

---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl: vanx
- tweak: Убрана возможность раундстартом взять роли центрального командования и синего щита, просите педалей.
