### PR TITLE
[Twe4k] Un-nerf stunb4ton 

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -13,7 +13,7 @@
     tags:
     - Stunbaton
   - type: Stunbaton
-    energyPerUse: 100 # WD EDIT
+    energyPerUse: 50 # WD EDIT
   - type: ItemToggle
     predictable: false
     soundActivate:
@@ -39,18 +39,18 @@
         Blunt: 7
     bluntStaminaDamageFactor: 2.0
     canHeavyAttack: false # WD EDIT
-    attackRate: 3 # WD EDIT
+    attackRate: 1 # WD EDIT
     angle: 60
   - type: DamageOtherOnHit
   - type: StaminaDamageOnHit
-    damage: 55 # WD EDIT
+    damage: 35 # WD EDIT
     sound: /Audio/Weapons/egloves.ogg
   - type: StaminaDamageOnCollide
     damage: 35
     sound: /Audio/Weapons/egloves.ogg
   - type: Battery
-    maxCharge: 1000
-    startingCharge: 1000
+    maxCharge: 750 # WD EDIT
+    startingCharge: 750 # WD EDIT
   - type: Item
     heldPrefix: off
     size: Normal


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

Исправление последствий непонятного нёрфа станбатонов - возможность сделать ОДИН удар в 3-4 секунды чувствуется просто отвратительно, из-за чего батон (особенно в харм режиме) невозможно юзать.

Вернул скорость атаки в 1 (чуть медленнее лома), уменьшил урон по стамине до 35 (для крита нужно 3 удара). 
В следствии увеличения необходимого кол-ва ударов на 50% поднял заряд до 15 ударов вместо 10.

---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl:
- tweak: Станбатон СБ теперь бьёт с обычной скоростью, но станит с трёх ударов.
