### PR TITLE
[Tweak] Movement In Crit + No Breaking Pull

### DIFF
--- a/Content.Shared/CCVar/CCVars.SoftCrit.cs
+++ b/Content.Shared/CCVar/CCVars.SoftCrit.cs
@@ -12,6 +12,10 @@ public sealed partial class CCVars
     public static readonly CVarDef<bool> AllowMovementWhileCrit =
         CVarDef.Create("mobstate.allow_movement_while_crit", true, CVar.REPLICATED);
 
+    // WWDP no breaking pulling in crit
+    public static readonly CVarDef<bool> AllowBreakingPullingWhileCrit =
+        CVarDef.Create("mobstate.allow_breaking_pulling_while_crit", false, CVar.REPLICATED);
+
     public static readonly CVarDef<bool> AllowTalkingWhileCrit =
         CVarDef.Create("mobstate.allow_talking_while_crit", true, CVar.REPLICATED);
 

--- a/Content.Shared/Mobs/Components/MobStateComponent.cs
+++ b/Content.Shared/Mobs/Components/MobStateComponent.cs
@@ -18,13 +18,13 @@ public sealed partial class MobStateComponent : Component
     ///     Whether this mob will be allowed to issue movement commands when in the Critical MobState.
     /// </summary>
     [DataField]
-    public bool AllowMovementWhileCrit;
+    public bool AllowMovementWhileCrit = true;
 
     /// <summary>
     ///     Whether this mob will be allowed to issue movement commands when in the Soft-Crit MobState.
     /// </summary>
     [DataField]
-    public bool AllowMovementWhileSoftCrit;
+    public bool AllowMovementWhileSoftCrit = true;
 
     /// <summary>
     ///     Whether this mob will be allowed to issue movement commands when in the Dead MobState.
@@ -32,6 +32,18 @@ public sealed partial class MobStateComponent : Component
     /// </summary>
     [DataField]
     public bool AllowMovementWhileDead;
+
+    /// <summary>
+    /// WWDP - Whether this mob will be allowed to break from being pulled.
+    /// </summary>
+    [DataField]
+    public bool AllowBreakingPullingWhileCrit;
+
+    [DataField]
+    public bool AllowBreakingPullingWhileSoftCrit;
+
+    [DataField]
+    public bool AllowBreakingPullingWhileDead;
 
     /// <summary>
     ///     Whether this mob will be allowed to talk while in the Critical MobState.

--- a/Content.Shared/Mobs/Components/MobStateComponent.cs
+++ b/Content.Shared/Mobs/Components/MobStateComponent.cs
@@ -18,13 +18,13 @@ public sealed partial class MobStateComponent : Component
     ///     Whether this mob will be allowed to issue movement commands when in the Critical MobState.
     /// </summary>
     [DataField]
-    public bool AllowMovementWhileCrit = true;
+    public bool AllowMovementWhileCrit = false;
 
     /// <summary>
     ///     Whether this mob will be allowed to issue movement commands when in the Soft-Crit MobState.
     /// </summary>
     [DataField]
-    public bool AllowMovementWhileSoftCrit = true;
+    public bool AllowMovementWhileSoftCrit = false;
 
     /// <summary>
     ///     Whether this mob will be allowed to issue movement commands when in the Dead MobState.

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -339,6 +339,10 @@
   - type: Shoving
   - type: BloodstreamAffectedByMass
     power: 0.6 # A minimum size felinid will have 30% blood, a minimum size vulp will have 60%, a maximum size oni will have ~200%
+  - type: MobState # WWDP
+    allowMovementWhileCrit: true
+    allowMovementWhileSoftCrit: true
+
 
 - type: entity
   save: false


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

Возвращает персонажам возможность ползать в критическом состоянии.
Теперь нельзя ползать, если персонажа держат-тащат.

---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl: vanx
- tweak: Персонажи снова могут ползать в крите
- tweak: Персонажи не могут ползать в крите если их схватить.
