### PR TITLE
[Fix] Embed Items Now Drop On Destruction/Deconstruction

### DIFF
--- a/Content.Server/Destructible/DestructibleSystem.cs
+++ b/Content.Server/Destructible/DestructibleSystem.cs
@@ -125,7 +125,7 @@ namespace Content.Server.Destructible
                     continue;
 
                 _projectile.RemoveEmbed(child, embed);
-                _throwing.TryThrow(child, _random.NextVector2() * 5, 5f, friction: 100f); // very short distance
+                _throwing.TryThrow(child, _random.NextVector2(), 1f, friction: 100f); // very short distance
             }
         }
 

--- a/Content.Server/Destructible/DestructibleSystem.cs
+++ b/Content.Server/Destructible/DestructibleSystem.cs
@@ -60,8 +60,8 @@ namespace Content.Server.Destructible
         {
             base.Initialize();
             SubscribeLocalEvent<DestructibleComponent, DamageChangedEvent>(Execute);
-            SubscribeLocalEvent<DestructibleComponent, DestructionEventArgs>(OnDestroyed);
-            SubscribeLocalEvent<DestructibleComponent, ConstructionBeforeDeleteEvent>(OnDeconstruct);
+            SubscribeLocalEvent<DestructibleComponent, DestructionEventArgs>(OnDestroyed); // WWDP
+            SubscribeLocalEvent<DestructibleComponent, ConstructionBeforeDeleteEvent>(OnDeconstruct); // WWDP
         }
 
         /// <summary>

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Content.Shared._Shitmed.Targeting;
+using Content.Shared.Item.ItemToggle;
 using Content.Shared.Throwing;
 using Content.Shared.UserInterface;
 using Robust.Shared.Audio.Systems;
@@ -50,7 +51,7 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         SubscribeLocalEvent<ProjectileComponent, PreventCollideEvent>(PreventCollision);
         SubscribeLocalEvent<EmbeddableProjectileComponent, ProjectileHitEvent>(OnEmbedProjectileHit);
         SubscribeLocalEvent<EmbeddableProjectileComponent, ThrowDoHitEvent>(OnEmbedThrowDoHit);
-        SubscribeLocalEvent<EmbeddableProjectileComponent, ActivateInWorldEvent>(OnEmbedActivate, before: new[] {typeof(ActivatableUISystem)}); // WD EDIT
+        SubscribeLocalEvent<EmbeddableProjectileComponent, ActivateInWorldEvent>(OnEmbedActivate, before: new[] {typeof(ActivatableUISystem), typeof(ItemToggleSystem), }); // WD EDIT
         SubscribeLocalEvent<EmbeddableProjectileComponent, RemoveEmbeddedProjectileEvent>(OnEmbedRemove);
         SubscribeLocalEvent<EmbeddableProjectileComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<EmbeddableProjectileComponent, PreventCollideEvent>(OnPreventCollision); // WD EDIT

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -94,8 +94,8 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         RaiseLocalEvent(uid, ref ev);
 
         // Whacky prediction issues.
-        if (_netManager.IsClient)
-            return;
+        //if (_netManager.IsClient) // WWDP disabled
+        //    return;
 
         if (component.DeleteOnRemove)
         {
@@ -127,6 +127,8 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         // try place it in the user's hand
         if (remover is {} removerUid)
             _hands.TryPickupAnyHand(removerUid, uid);
+
+        Dirty(uid, component); // WWDP
     }
 
     private void OnEmbedThrowDoHit(EntityUid uid, EmbeddableProjectileComponent component, ThrowDoHitEvent args)

--- a/Resources/Locale/en-US/weapons/throwing/throwing.ftl
+++ b/Resources/Locale/en-US/weapons/throwing/throwing.ftl
@@ -2,5 +2,5 @@ throwing-falloff = The {$item} falls out of you!
 throwing-embed-falloff = The {$item} falls out of you!
 throwing-embed-remove-alert-owner = {$other} is removing the {$item} stuck on you!
 
-throwing-examine-embedded = {CAPITALIZE(OBJECT($embedded))} {CONJUGATE-BE($embedded)} [color=teal]embedded[/color] in [bold]{THE($target)}[/bold].
-throwing-examine-embedded-part = {CAPITALIZE(OBJECT($embedded))} {CONJUGATE-BE($embedded)} [color=teal]embedded[/color] in [bold]{THE($target)}[/bold]'s [color=red]{$targetPart}[/color].
+throwing-examine-embedded = {CAPITALIZE(SUBJECT($embedded))} {CONJUGATE-BE($embedded)} [color=teal]embedded[/color] in [bold]{THE($target)}[/bold].
+throwing-examine-embedded-part = {CAPITALIZE(SUBJECT($embedded))} {CONJUGATE-BE($embedded)} [color=teal]embedded[/color] in [bold]{THE($target)}[/bold]'s [color=red]{$targetPart}[/color].

--- a/Resources/Locale/ru-RU/weapons/throwing/throwing.ftl
+++ b/Resources/Locale/ru-RU/weapons/throwing/throwing.ftl
@@ -1,0 +1,6 @@
+throwing-falloff = {$item} выпадает из вас!
+throwing-embed-falloff = {$item} выпадает из вас!
+throwing-embed-remove-alert-owner = {$other} достаёт {$item}, застрявший в вас!
+
+throwing-examine-embedded = {CAPITALIZE(SUBJECT($embedded))} [color=teal]застрял[/color] в [bold]{THE($target)}[/bold].
+throwing-examine-embedded-part = {CAPITALIZE(SUBJECT($embedded))} [color=teal]застрял[/color] в [color=red]{$targetPart}[/color] [bold]{target}[/bold].

--- a/Resources/Locale/ru-RU/weapons/throwing/throwing.ftl
+++ b/Resources/Locale/ru-RU/weapons/throwing/throwing.ftl
@@ -2,5 +2,5 @@ throwing-falloff = {$item} выпадает из вас!
 throwing-embed-falloff = {$item} выпадает из вас!
 throwing-embed-remove-alert-owner = {$other} достаёт {$item}, застрявший в вас!
 
-throwing-examine-embedded = {CAPITALIZE(SUBJECT($embedded))} [color=teal]застрял[/color] в [bold]{THE($target)}[/bold].
+throwing-examine-embedded = {CAPITALIZE(SUBJECT($embedded))} [color=teal]застрял[/color] в [bold]{$target}[/bold].
 throwing-examine-embedded-part = {CAPITALIZE(SUBJECT($embedded))} [color=teal]застрял[/color] в [color=red]{$targetPart}[/color] [bold]{target}[/bold].


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

Застрявшие предметы теперь выпадают при разрушении или разборке.
Добавлена локализация.

---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl: vanx
- fix: Застрявшие предметы теперь выпадают при разрушении или разборке.
