### PR TITLE
[Fix] Less Surgery Spam & Icon Fixes

### DIFF
--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
@@ -324,14 +324,14 @@
   - type: SurgeryStep
     tool:
     - type: Tending
-    duration: 1
+    duration: 2 # WWDP less spam
   - type: Sprite
-    sprite: _Shitmed/Objects/Specific/Medical/Surgery/retractor.rsi # WD EDIT
-    state: retractor # WD EDIT
+    sprite: _Shitmed/Objects/Specific/Medical/Surgery/hemostat.rsi # WD EDIT
+    state: hemostat # WD EDIT
   - type: SurgeryTendWoundsEffect
     damage:
       groups:
-        Brute: -5
+        Brute: -10 # WWDP
   - type: SurgeryRepeatableStep
 
 - type: entity
@@ -343,15 +343,15 @@
   - type: SurgeryStep
     tool:
     - type: Tending
-    duration: 1
+    duration: 2 # WWDP less spam
   - type: Sprite
-    sprite: _Shitmed/Objects/Specific/Medical/Surgery/retractor.rsi # WD EDIT
-    state: retractor # WD EDIT
+    sprite: _Shitmed/Objects/Specific/Medical/Surgery/hemostat.rsi # WWDP
+    state: hemostat # WWDP
   - type: SurgeryTendWoundsEffect
     mainGroup: Burn
     damage:
       groups:
-        Burn: -5
+        Burn: -10 # WWDP
   - type: SurgeryRepeatableStep
 
 - type: entity


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

Скорость лечения ран и ожогов хирургией уменьшена в 2 раза, восстанавливаемое здоровье увеличено в 2 раза - чтобы было меньше спама дуафтером.
Исправлены иконки необходимых инструментов.

---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

small fix no cl
