### PR TITLE
decal rename fix

### DIFF
--- a/Resources/Maps/Moose.yml
+++ b/Resources/Maps/Moose.yml
@@ -7908,7 +7908,7 @@ entities:
             cleanable: True
             angle: 0.6981317007977318 rad
             color: '#C1AAAC6D'
-            id: questionmark
+            id: qmark
           decals:
             2158: -29,-26
         - node:

--- a/Resources/Maps/Salvage/DeltaV/DV-med-crashed-shuttle.yml
+++ b/Resources/Maps/Salvage/DeltaV/DV-med-crashed-shuttle.yml
@@ -87,7 +87,7 @@ entities:
             5: -2,-1
         - node:
             color: '#79150096'
-            id: questionmark
+            id: qmark
           decals:
             4: -2,4
         - node:

--- a/Resources/Maps/Salvage/DeltaV/DV-med-library.yml
+++ b/Resources/Maps/Salvage/DeltaV/DV-med-library.yml
@@ -105,13 +105,13 @@ entities:
         - node:
             angle: -1.5707963267948966 rad
             color: '#DE3A3A1B'
-            id: exclamationmark
+            id: emark
           decals:
             59: -2.0519302,2.6656694
             60: -1.2394302,2.9469194
         - node:
             color: '#DE3A3A1B'
-            id: exclamationmark
+            id: emark
           decals:
             52: -3.2550552,-1.8968306
             53: -2.9581802,-1.0999556

--- a/Resources/Maps/Salvage/DeltaV/DV-tick-colony.yml
+++ b/Resources/Maps/Salvage/DeltaV/DV-tick-colony.yml
@@ -98,7 +98,7 @@ entities:
             7: -1,3
         - node:
             color: '#79150063'
-            id: exclamationmark
+            id: emark
           decals:
             44: -3.8162756,-0.24618945
             45: -4.0350256,0.20693552
@@ -113,7 +113,7 @@ entities:
         - node:
             angle: 1.5707963267948966 rad
             color: '#79150063'
-            id: exclamationmark
+            id: emark
           decals:
             54: -1.4215076,-5.2462125
             55: -1.8590076,-4.8555875

--- a/Resources/Maps/Salvage/medium-crashed-shuttle.yml
+++ b/Resources/Maps/Salvage/medium-crashed-shuttle.yml
@@ -87,7 +87,7 @@ entities:
             5: -2,-1
         - node:
             color: '#79150096'
-            id: questionmark
+            id: qmark
           decals:
             4: -2,4
         - node:

--- a/Resources/Maps/Salvage/medium-library.yml
+++ b/Resources/Maps/Salvage/medium-library.yml
@@ -105,13 +105,13 @@ entities:
         - node:
             angle: -1.5707963267948966 rad
             color: '#DE3A3A1B'
-            id: exclamationmark
+            id: emark
           decals:
             59: -2.0519302,2.6656694
             60: -1.2394302,2.9469194
         - node:
             color: '#DE3A3A1B'
-            id: exclamationmark
+            id: emark
           decals:
             52: -3.2550552,-1.8968306
             53: -2.9581802,-1.0999556

--- a/Resources/Maps/Salvage/tick-colony.yml
+++ b/Resources/Maps/Salvage/tick-colony.yml
@@ -98,7 +98,7 @@ entities:
             7: -1,3
         - node:
             color: '#79150063'
-            id: exclamationmark
+            id: emark
           decals:
             44: -3.8162756,-0.24618945
             45: -4.0350256,0.20693552
@@ -113,7 +113,7 @@ entities:
         - node:
             angle: 1.5707963267948966 rad
             color: '#79150063'
-            id: exclamationmark
+            id: emark
           decals:
             54: -1.4215076,-5.2462125
             55: -1.8590076,-4.8555875


### PR DESCRIPTION
# Описание PR

Сократить "exclamationmark" до "emark" я сократил, а вот переименовать все использования "exclamationmark" в картах в "emark" я забыл.

---
