### PR TITLE
[REMOVE] это пиздец-с господа

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Belt/belts.yml
@@ -8,7 +8,7 @@
     sprite: _Goobstation/Clothing/Belt/judobelt.rsi
   - type: Clothing
     sprite: _Goobstation/Clothing/Belt/judobelt.rsi
-  - type: GrantCorporateJudo
+  #- type: GrantCorporateJudo # wwdp edit, get fucked.
   - type: Storage
     whitelist:
       tags:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/kravmagagloves.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/kravmagagloves.yml
@@ -11,6 +11,6 @@
   - type: Fiber
     fiberMaterial: fibers-leather
     fiberColor: fibers-red
-  - type: ClothingGrantComponent
-    component:
-    - type: KravMaga
+  #- type: ClothingGrantComponent # wwdp edit, get fucked (until futher notice)
+  #  component:
+  #  - type: KravMaga

--- a/Resources/Prototypes/_White/Loadouts/Jobs/maid.yml
+++ b/Resources/Prototypes/_White/Loadouts/Jobs/maid.yml
@@ -386,19 +386,19 @@
   - SpeedLoaderMagnum
   - SpeedLoaderMagnum
 
-- type: loadout
-  id: LoadoutMaidCQCManual
-  category: JobsCommandMaid
-  cost: 6
-  exclusive: true
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutMaidPrimary
-  - !type:CharacterJobRequirement
-    jobs:
-    - Maid
-  items:
-  - BSOManual
+#- type: loadout
+#  id: LoadoutMaidCQCManual
+#  category: JobsCommandMaid
+#  cost: 6
+#  exclusive: true
+#  requirements:
+#  - !type:CharacterItemGroupRequirement
+#    group: LoadoutMaidPrimary
+#  - !type:CharacterJobRequirement
+#    jobs:
+#    - Maid
+#  items:
+#  - BSOManual
 
 # Secondary
 


### PR DESCRIPTION
# Описание PR

В том виде, в каком они существуют сейчас - крав мага и дзюдо это просто пиздец.
Дзюдо даёт возможность офицерикам инстаграбать людей и кинуть их в стенку - это мгновенный стан.
Крав-мага на схожем уровне, одна тычка даёт стаминакрит в четыре секунды.
Дзюдо уже не спасти, крав магу ещё можно адекватно понёрфить, как минимум повысив КД всем абилкам.

---

# Медиа

N/A

# Изменения

:cl:
- remove: Пояса дзюдо и крав-мага с начала раунда. Уходит на переработку в следствии сломанного баланса. 
