### PR TITLE
[Fix] Input Relays Running State

### DIFF
--- a/Content.Shared/CCVar/CCVars.Interactions.cs
+++ b/Content.Shared/CCVar/CCVars.Interactions.cs
@@ -20,7 +20,7 @@ public sealed partial class CCVars
     /// Whether the player mob is walking by default instead of running.
     /// </summary>
     public static readonly CVarDef<bool> DefaultWalk =
-        CVarDef.Create("control.default_walk", true, CVar.CLIENT | CVar.REPLICATED | CVar.ARCHIVE);
+        CVarDef.Create("control.default_walk", false, CVar.CLIENT | CVar.REPLICATED | CVar.ARCHIVE); // WWDP
 
     // The rationale behind the default limit is simply that I can easily get to 7 interactions per second by just
     // trying to spam toggle a light switch or lever (though the UseDelay component limits the actual effect of the

--- a/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
@@ -355,6 +355,8 @@ namespace Content.Shared.Movement.Systems
 
             if (TryComp<RelayInputMoverComponent>(uid, out var relayMover))
             {
+                HandleRunChange(relayMover.RelayEntity, subTick, !walking); // WWDP moved up & !walking
+
                 // if we swap to relay then stop our existing input if we ever change back.
                 if (moverComp != null)
                 {
@@ -362,13 +364,12 @@ namespace Content.Shared.Movement.Systems
                     WalkingAlert((uid, moverComp));
                 }
 
-                HandleRunChange(relayMover.RelayEntity, subTick, walking);
-                return;
+                //return; // WWDP
             }
 
             if (moverComp == null) return;
 
-            SetSprinting((uid, moverComp), subTick, walking);
+            SetSprinting(uid, subTick, walking);
         }
 
         public (Vector2 Walking, Vector2 Sprinting) GetVelocityInput(InputMoverComponent mover)
@@ -475,12 +476,17 @@ namespace Content.Shared.Movement.Systems
             component.LastInputSubTick = 0;
         }
 
-        public void SetSprinting(Entity<InputMoverComponent> entity, ushort subTick, bool walking)
+        public void SetSprinting(EntityUid entity, ushort subTick, bool walking)
         {
             // Logger.Info($"[{_gameTiming.CurTick}/{subTick}] Sprint: {enabled}");
 
-            SetMoveInput(entity, subTick, walking, MoveButtons.Walk);
-            WalkingAlert(entity);
+            if (!TryComp<InputMoverComponent>(entity, out var input))
+                return;
+
+            var entityComp = new Entity<InputMoverComponent>(owner:entity, comp:input);
+
+            SetMoveInput(entityComp, subTick, walking, MoveButtons.Walk);
+            WalkingAlert(entityComp);
         }
 
         /// <summary>

--- a/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
@@ -476,6 +476,7 @@ namespace Content.Shared.Movement.Systems
             component.LastInputSubTick = 0;
         }
 
+        // WWDP edited
         public void SetSprinting(EntityUid entity, ushort subTick, bool walking)
         {
             // Logger.Info($"[{_gameTiming.CurTick}/{subTick}] Sprint: {enabled}");
@@ -488,6 +489,7 @@ namespace Content.Shared.Movement.Systems
             SetMoveInput(entityComp, subTick, walking, MoveButtons.Walk);
             WalkingAlert(entityComp);
         }
+        // WWDP edit end
 
         /// <summary>
         ///     Retrieves the normalized direction vector for a specified combination of movement keys.

--- a/Content.Shared/Movement/Systems/SharedMoverController.Relay.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Relay.cs
@@ -53,6 +53,13 @@ public abstract partial class SharedMoverController
             Physics.UpdateIsPredicted(targetComp.Source);
         }
 
+        if (TryComp<InputMoverComponent>(uid, out var oldMover) &&
+            HasComp<InputMoverComponent>(relayEntity))
+        {
+            ushort subtick = default;
+            SetSprinting(relayEntity, subtick, oldMover.Sprinting);
+        }
+
         Physics.UpdateIsPredicted(uid);
         Physics.UpdateIsPredicted(relayEntity);
         component.RelayEntity = relayEntity;

--- a/Content.Shared/Movement/Systems/SharedMoverController.Relay.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Relay.cs
@@ -53,12 +53,14 @@ public abstract partial class SharedMoverController
             Physics.UpdateIsPredicted(targetComp.Source);
         }
 
+        // WWDP edit
         if (TryComp<InputMoverComponent>(uid, out var oldMover) &&
             HasComp<InputMoverComponent>(relayEntity))
         {
             ushort subtick = default;
             SetSprinting(relayEntity, subtick, oldMover.Sprinting);
         }
+        // WWDP edit end
 
         Physics.UpdateIsPredicted(uid);
         Physics.UpdateIsPredicted(relayEntity);


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

Бег по дефолту в цварах.
InputRelay теперь корректно принимает изначальный бег/шаг и обновляет соответствующе.

---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl: vanx
- fix: Бег в мехах теперь работает по умолчанию и показывается на интерфейсе.
