### PR TITLE
[Tweak] Shotguns Requiring 2 Hands

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -1040,7 +1040,7 @@
   - type: Tag
     tags:
     - HighRiskItem
-  - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
+  # - type: GunRequiresWield #remove when inaccuracy on spreads is fixed # WWDP disabled
   - type: Battery
     maxCharge: 1210
     startingCharge: 1210

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -68,7 +68,7 @@
         Blunt: 2.5
   - type: DamageOtherOnHit
     staminaCost: 9.5
-  - type: GunRequiresWield # WD EDIT
+  # - type: GunRequiresWield # WD EDIT # WWDP disabled
   - type: EmitSoundOnPickup # WWDP sounds
     sound:
       collection: ShotgunsPickUp
@@ -121,7 +121,7 @@
     - Back
     - suitStorage
   # - type: AmmoCounter # WWDP
-  - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
+  # - type: GunRequiresWield #remove when inaccuracy on spreads is fixed # WWDP disabled
   - type: Gun
     bonusAngleIncreaseMove: 40    # wwdp
     bonusAngleIncreaseTurn: 0.25  # wwdp


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

Описание.
CL

---

# Медиа

![изображение](https://github.com/user-attachments/assets/49f1a91e-6ac5-4e2b-abec-3a8d5783252d)
![изображение](https://github.com/user-attachments/assets/9ccd2969-a14b-4880-8ecd-3e3f113ed3d8)
![изображение](https://github.com/user-attachments/assets/49e1676c-cd26-477a-8fdc-3cf54ee14cc0)
(без движения/в движении)
---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl: vanx
- tweak: Теперь из дробовиков можно стрелять одной рукой с крайне низкой точностью
