### PR TITLE
[Fix] Faction Identification

### DIFF
--- a/Content.Shared/NPC/Systems/NpcFactionSystem.cs
+++ b/Content.Shared/NPC/Systems/NpcFactionSystem.cs
@@ -30,6 +30,7 @@ public sealed partial class NpcFactionSystem : EntitySystem
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnProtoReload);
 
         InitializeException();
+        InitializeItems(); // WWDP
         RefreshFactions();
     }
 


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

:cl: vanx
- fix: Турели и NPC синдиката теперь распознают своих по КПК синдиката/айди карте синдиката в слоте КПК.
