### PR TITLE
[FIX] Disable PsychoHistorian & Elementalist

### DIFF
--- a/Resources/Prototypes/Traits/Psionics/casterTypes.yml
+++ b/Resources/Prototypes/Traits/Psionics/casterTypes.yml
@@ -66,6 +66,7 @@
   id: PsychoHistorian
   category: TraitsPsionicsCasterTypes
   points: -4
+  enable: false #WWDP EDIT
   functions:
     - !type:TraitAddComponent
       components:
@@ -106,6 +107,7 @@
   id: Elementalist
   category: TraitsPsionicsCasterTypes
   points: -5
+  enable: false #WWDP EDIT
   functions:
     - !type:TraitAddComponent
       components:

--- a/Resources/Prototypes/Traits/Psionics/elementalistShop.yml
+++ b/Resources/Prototypes/Traits/Psionics/elementalistShop.yml
@@ -2,6 +2,7 @@
   id: ElementalistAnoigoPower
   category: TraitsPsionicsPowers
   points: -10
+  enable: false #WWDP EDIT
   requirements:
     - !type:CharacterTraitRequirement
       traits:
@@ -15,6 +16,7 @@
   id: ElementalistHealingWordPower
   category: TraitsPsionicsPowers
   points: -5
+  enable: false #WWDP EDIT
   requirements:
     - !type:CharacterTraitRequirement
       traits:
@@ -28,6 +30,7 @@
   id: ElementalistRevivifyPower
   category: TraitsPsionicsPowers
   points: -10
+  enable: false #WWDP EDIT
   requirements:
     - !type:CharacterTraitRequirement
       traits:
@@ -41,6 +44,7 @@
   id: ElementalistShadeskipPower
   category: TraitsPsionicsPowers
   points: -3
+  enable: false #WWDP EDIT
   requirements:
     - !type:CharacterTraitRequirement
       traits:
@@ -54,6 +58,7 @@
   id: ElementalistDarkSwapPower
   category: TraitsPsionicsPowers
   points: -10
+  enable: false #WWDP EDIT
   requirements:
     - !type:CharacterTraitRequirement
       traits:
@@ -67,6 +72,7 @@
   id: ElementalistTelekineticPulsePower
   category: TraitsPsionicsPowers
   points: -5
+  enable: false #WWDP EDIT
   requirements:
     - !type:CharacterTraitRequirement
       traits:
@@ -80,6 +86,7 @@
   id: ElementalistPyrokineticFlarePower
   category: TraitsPsionicsPowers
   points: -4
+  enable: false #WWDP EDIT
   requirements:
     - !type:CharacterTraitRequirement
       traits:
@@ -93,6 +100,7 @@
   id: ElementalistNoosphericZapPower
   category: TraitsPsionicsPowers
   points: -6
+  enable: false #WWDP EDIT
   requirements:
     - !type:CharacterTraitRequirement
       traits:

--- a/Resources/Prototypes/Traits/Psionics/psychoHistorianShop.yml
+++ b/Resources/Prototypes/Traits/Psionics/psychoHistorianShop.yml
@@ -2,6 +2,7 @@
   id: PsychoHistorianMetapsionicPower
   category: TraitsPsionicsPowers
   points: -2
+  enable: false #WWDP EDIT
   requirements:
     - !type:CharacterTraitRequirement
       traits:
@@ -15,6 +16,7 @@
   id: PsychoHistorianDispelPower
   category: TraitsPsionicsPowers
   points: -2
+  enable: false #WWDP EDIT
   requirements:
     - !type:CharacterTraitRequirement
       traits:
@@ -28,6 +30,7 @@
   id: PsychoHistorianTelegnosisPower
   category: TraitsPsionicsPowers
   points: -5
+  enable: false #WWDP EDIT
   requirements:
     - !type:CharacterTraitRequirement
       traits:
@@ -55,6 +58,7 @@
   id: PsychoHistorianPsionicInvisibilityPower
   category: TraitsPsionicsPowers
   points: -8
+  enable: false #WWDP EDIT
   requirements:
     - !type:CharacterTraitRequirement
       traits:
@@ -68,6 +72,7 @@
   id: PsychoHistorianXenoglossyPower
   category: TraitsPsionicsPowers
   points: -2
+  enable: false #WWDP EDIT
   requirements:
     - !type:CharacterTraitRequirement
       traits:
@@ -81,6 +86,7 @@
   id: PsychoHistorianPsychognomyPower
   category: TraitsPsionicsPowers
   points: -2
+  enable: false #WWDP EDIT
   requirements:
     - !type:CharacterTraitRequirement
       traits:
@@ -94,6 +100,7 @@
   id: PsychoHistorianAssayPower
   category: TraitsPsionicsPowers
   points: -2
+  enable: false #WWDP EDIT
   requirements:
     - !type:CharacterTraitRequirement
       traits:


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

Давать псионикам опасные способности с старта без рандома - плохо

---


# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl:
- remove: Убраны трейты Psycho-Historian и  Elementalist
