### PR TITLE
[Tweak] Взаимодействия снарядов с мебелью

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -1227,6 +1227,7 @@
         hard: false
         mask:
         - Opaque # WWDP allow shooting through windows
+        - BulletImpassable # WWDP edit
       fly-by: *flybyfixture
   - type: Ammo
     muzzleFlash: null # WWDP

--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -19,6 +19,9 @@
         density: 100
         mask:
         - TableMask
+        layer:
+        - TableLayer
+        - BulletImpassable
   - type: Sprite
     sprite: Structures/Furniture/chairs.rsi
     noRot: true

--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -19,9 +19,11 @@
         density: 100
         mask:
         - TableMask
+# WWDP edit start
         layer:
         - TableLayer
         - BulletImpassable
+# WWDP edit end
   - type: Sprite
     sprite: Structures/Furniture/chairs.rsi
     noRot: true

--- a/Resources/Prototypes/Entities/Structures/Storage/storage.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/storage.yml
@@ -30,6 +30,7 @@
         - TableMask
         layer:
         - TableLayer
+        - BulletImpassable # WWDP edit
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic
@@ -58,5 +59,6 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: Climbable
+  - type: RequireProjectileTarget # WWDP edit
   - type: StaticPrice
     price: 22


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

Для общего прототипа всех стульев и прототипа стоек: добавлен слой коллизии BulletImpassable к стойкам для обработки попадания пули, а так же  RequireProjectileTarget для определения цели. 

Так же, в маску для лазерных снарядов добавил BulletImpassable, позволяя лазерам ебашить столы и стойки, нанося им тепловой урон. 

Для чего? А собсна сегодня столкнулся с такой ситуацией: генокрад, будучи загнанной в угол крысой, лег под стойку и ушел в анальную оборону, поскольку попасть по нему невозможно, а идти в ближний бой - получить мгновенное опездюливание. Всем отделом сб в час пик устраивали генг-бенг, кое-как выкурив его, попутно разъебав прилегающие комнаты РНД. 

Если бы у чехов в 41-ом были эти стойки и диваны...

---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl: Kutos
- tweak: Стойки и диваны теперь расстреливаются
- tweak: Лазеры теперь могут уничтожать мебель