### PR TITLE
[Tweak] Sec Guns Rebalance

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -165,6 +165,7 @@
     fireCost: 25 # wwdp
   - type: GunOverheat # wwdp
     heatCost: 20
+    temperatureLimit: 240
   - type: EnergyGun
     fireModes:
     - proto: BulletDisabler
@@ -243,6 +244,7 @@
     fireCost: 25 # wwdp
   - type: GunOverheat # wwdp
     heatCost: 20
+    temperatureLimit: 240
   - type: EnergyGun
     fireModes:
     - proto: BulletDisabler

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -331,6 +331,7 @@
     angleIncrease: 8
     angleDecay: 9
     fireRate: 4
+    damageModifier: 0.74 # WWDP; 35 -> 25.9 dmg
     availableModes:
     - SemiAuto
     soundGunshot:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -1090,7 +1090,7 @@
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:
       types:
-        Heat: 28
+        Heat: 30
 
 - type: entity
   name : disabler bolt
@@ -1189,7 +1189,7 @@
     impactEffect: BulletImpactEffectLaserRed # WWDP
     damage:
       types:
-        Heat: 12 # WWDP less powerful laser
+        Heat: 20 # WWDP less powerful laser
     soundHit:
       collection: MeatLaserImpact
   - type: PointLight # WWDP
@@ -1234,7 +1234,7 @@
     impactEffect: BulletImpactEffectLaserRed # WD EDIT
     damage:
       types:
-        Heat: 17 # WWDP
+        Heat: 25 # WWDP
     soundHit:
       collection: MeatLaserImpact # WWDP
     forceSound: true
@@ -1281,7 +1281,7 @@
   - type: Projectile
     damage:
       types:
-        Heat: 28 # WD EDIT
+        Heat: 30 # WD EDIT
   # WD EDIT START
   - type: PointLight
     radius: 3.0

--- a/Resources/Prototypes/_White/Entities/Objects/Weapons/Guns/Projectiles/bolts..yml
+++ b/Resources/Prototypes/_White/Entities/Objects/Weapons/Guns/Projectiles/bolts..yml
@@ -73,8 +73,8 @@
     impactEffect: BulletImpactEffectLaserGreen
     damage:
       types:
-        Heat: 10
-        Radiation: 10
+        Heat: 15 # WWDP
+        Radiation: 15 # WWDP
   - type: PointLight
     color: green
 


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

- Ребаланс табельного оружия СБ
- Бафф и стандартизация лазерных проджектайлов

Урон N1984: 35 -> 26

Урон лазеров:
Маленький (пистолеты): 12 -> 20
Обычный (винтовка, антиквар): 17 -> 25
Большой (пушка): 28 -> 30

Температура перегрева лазерных пистолетов: 150 -> 240
Выстрелов до перегрева: 4 -> 7

---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl: vanx
- tweak: Урон пистолета N1984: 35 -> 26.
- tweak: Лазерные пистолеты теперь дольше не перегреваются.
- tweak: Повышен урон лазеров, было: 12-17-28, стало: 20-25-30.