### PR TITLE
[Tweak] .45 Pistol

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -19,6 +19,7 @@
     angleIncrease: 6
     angleDecay: 6
     fireRate: 2.5
+    damageModifier: 0.74 # WWDP; 35 -> 25.9 dmg
     availableModes:
     - SemiAuto
     soundGunshot:


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

Урон пистолета Universal: 35 -> 26
По аналогии с N1984, не затрагивает урон остальных пушек .45

:cl: vanx
- tweak: Урон пистолета Universal: 35 -> 26.
