### PR TITLE
[Tweak] Starting Loot

### DIFF
--- a/Resources/Migrations/WWDPMigration.yml
+++ b/Resources/Migrations/WWDPMigration.yml
@@ -62,3 +62,4 @@ UniqueLockerNanorepFilled: null
 UniqueLockerBlueshieldOfficerFilled: null
 UniqueLockerMagistrateFilled: null
 ClothingOuterHardsuitBlueshield: null
+AntimovCircuitBoard: null

--- a/Resources/Migrations/WWDPMigration.yml
+++ b/Resources/Migrations/WWDPMigration.yml
@@ -56,3 +56,9 @@ CartridgeRocket: null
 LockerNanorepFilled: null
 LockerMagistrateFilled: null
 LockerBlueshieldOfficerFilled: null
+
+# 08-06-2025
+UniqueLockerNanorepFilled: null
+UniqueLockerBlueshieldOfficerFilled: null
+UniqueLockerMagistrateFilled: null
+ClothingOuterHardsuitBlueshield: null

--- a/Resources/Migrations/WWDPMigration.yml
+++ b/Resources/Migrations/WWDPMigration.yml
@@ -63,3 +63,4 @@ UniqueLockerBlueshieldOfficerFilled: null
 UniqueLockerMagistrateFilled: null
 ClothingOuterHardsuitBlueshield: null
 AntimovCircuitBoard: null
+ClothingShoesGaloshes: null # munch begone

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
@@ -134,7 +134,7 @@
     contents:
       # - id: Flash # WWDP
       - id: TelescopicBaton # WWDP
-      - id: MagazinePistol
+      # - id: MagazinePistol # WWDP
 
 - type: entity
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
@@ -72,9 +72,9 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
+      # - id: Flash # WWDP
       #- name: StationCharter
-      #- name: TelescopicBaton
+      - id: TelescopicBaton # WWDP
 - type: entity
   categories: [ HideSpawnMenu ]
   parent: ClothingBackpackEngineering
@@ -82,8 +82,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
-      #- id: TelescopicBaton
+      # - id: Flash # WWDP
+      - id: TelescopicBaton # WWDP
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -92,8 +92,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
-      #- id: TelescopicBaton
+      # - id: Flash # WWDP
+      - id: TelescopicBaton # WWDP
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -102,8 +102,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
-      #- id: TelescopicBaton
+      # - id: Flash # WWDP
+      - id: TelescopicBaton # WWDP
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -112,8 +112,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
-      #- id: TelescopicBaton
+      # - id: Flash # WWDP
+      - id: TelescopicBaton # WWDP
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -122,8 +122,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
-      #- id: TelescopicBaton
+      # - id: Flash # WWDP
+      - id: TelescopicBaton # WWDP
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -132,7 +132,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
+      # - id: Flash # WWDP
+      - id: TelescopicBaton # WWDP
       - id: MagazinePistol
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
@@ -179,6 +179,11 @@
   categories: [ HideSpawnMenu ]
   parent: ClothingBackpack
   id: ClothingBackpackChaplainFilled
+  components: # WWDP filled
+  - type: StorageFill
+    contents:
+    - id: Bible
+    - id: RubberStampChaplain
 
 - type: entity
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/duffelbag.yml
@@ -68,9 +68,9 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
+      - id: Flash # WWDP
       #- name: StationCharter
-      #- name: TelescopicBaton
+      - id: TelescopicBaton # WWDP
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -79,8 +79,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
-      #- id: TelescopicBaton
+      #- id: Flash # WWDP
+      - id: TelescopicBaton # WWDP
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -89,8 +89,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
-      #- id: TelescopicBaton
+      # - id: Flash # WWDP
+      - id: TelescopicBaton # WWDP
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -99,8 +99,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
-      #- id: TelescopicBaton
+      # - id: Flash # WWDP
+      - id: TelescopicBaton # WWDP
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -109,8 +109,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
-      #- id: TelescopicBaton
+    # - id: Flash # WWDP
+    - id: TelescopicBaton # WWDP
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -119,8 +119,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
-      #- id: TelescopicBaton
+    # - id: Flash # WWDP
+    - id: TelescopicBaton # WWDP
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -129,7 +129,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
+      # - id: Flash # WWDP
+      - id: TelescopicBaton # WWDP
       - id: MagazinePistol
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/satchel.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/satchel.yml
@@ -85,9 +85,9 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
+      # - id: Flash # WWDP
       #- name: StationCharter
-      #- name: TelescopicBaton
+      - id: TelescopicBaton # WWDP
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -96,8 +96,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
-      #- id: TelescopicBaton
+      # - id: Flash # WWDP
+      - id: TelescopicBaton # WWDP
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -106,8 +106,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
-      #- id: TelescopicBaton
+      # - id: Flash # WWDP
+      - id: TelescopicBaton # WWDP
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -116,8 +116,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
-      #- id: TelescopicBaton
+      # - id: Flash # WWDP
+      - id: TelescopicBaton # WWDP
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -126,8 +126,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
-      #- id: TelescopicBaton
+      # - id: Flash # WWDP
+      - id: TelescopicBaton # WWDP
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -136,8 +136,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
-      #- id: TelescopicBaton
+      # - id: Flash # WWDP
+      - id: TelescopicBaton # WWDP
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -146,7 +146,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: Flash
+      # - id: Flash # WWDP
+      - id: TelescopicBaton # WWDP
       - id: MagazinePistol
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Items/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/misc.yml
@@ -17,14 +17,3 @@
     containers:
       item:
       - KukriKnife
-
-# WWDP
-- type: entity
-  id: ClothingShoesBootsSalvageFilled
-  parent: ClothingShoesBootsSalvage
-  suffix: Filled
-  components:
-  - type: ContainerFill
-    containers:
-      item:
-      - SurvivalKnife

--- a/Resources/Prototypes/Catalog/Fills/Items/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/misc.yml
@@ -18,3 +18,13 @@
       item:
       - KukriKnife
 
+# WWDP
+- type: entity
+  id: ClothingShoesBootsSalvageFilled
+  parent: ClothingShoesBootsSalvage
+  suffix: Filled
+  components:
+  - type: ContainerFill
+    containers:
+      item:
+      - SurvivalKnife

--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -13,7 +13,7 @@
       - id: HandheldGPSBasic
       - id: RadioHandheld
       - id: FlashlightLantern # WWDP
-      - id: ClothingHandsGlovesColorBrown # WWDP
+      - id: ClothingHandsGlovesColorBlack # WWDP
       - id: Pickaxe
       - id: ClothingShoesBootsWinterMiner #Delta V: Add departmental winter boots
       - id: JetpackMiniFilled # DeltaV - Salv lost their shuttle
@@ -52,7 +52,7 @@
       - id: HandheldGPSBasic
       - id: RadioHandheld
       - id: FlashlightLantern # WWDP
-      - id: ClothingHandsGlovesColorBrown # WWDP
+      - id: ClothingHandsGlovesColorBlack # WWDP
       - id: Pickaxe
       - id: ClothingShoesBootsWinterMiner #Delta V: Add departmental winter boots
       - id: JetpackMiniFilled # DeltaV - Salv lost their shuttle

--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -15,7 +15,7 @@
       - id: FlashlightLantern # WWDP
       - id: ClothingHandsGlovesColorBlack # WWDP
       - id: Pickaxe
-      - id: ClothingShoesBootsWinterMiner #Delta V: Add departmental winter boots
+      #- id: ClothingShoesBootsWinterMiner #Delta V: Add departmental winter boots # WWDP no
       - id: JetpackMiniFilled # DeltaV - Salv lost their shuttle
       - id: OreBag
       - id: Flare
@@ -54,7 +54,7 @@
       - id: FlashlightLantern # WWDP
       - id: ClothingHandsGlovesColorBlack # WWDP
       - id: Pickaxe
-      - id: ClothingShoesBootsWinterMiner #Delta V: Add departmental winter boots
+      #- id: ClothingShoesBootsWinterMiner #Delta V: Add departmental winter boots # WWDP no
       - id: JetpackMiniFilled # DeltaV - Salv lost their shuttle
       - id: OreBag
       - id: Flare

--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -12,7 +12,8 @@
       - id: SurvivalKnife
       - id: HandheldGPSBasic
       - id: RadioHandheld
-      - id: FlashlightSeclite
+      - id: FlashlightLantern # WWDP
+      - id: ClothingHandsGlovesColorBrown # WWDP
       - id: Pickaxe
       - id: ClothingShoesBootsWinterMiner #Delta V: Add departmental winter boots
       - id: JetpackMiniFilled # DeltaV - Salv lost their shuttle
@@ -29,12 +30,12 @@
         prob: 0.3
       # Lavaland Change Start
       - id: WeaponProtoKineticAccelerator
-      - id: OreBag
-      - id: Pickaxe
-      - id: LavalandEquipmentExplorerSuit
+      # - id: OreBag # WWDP remove duplicate
+      # - id: Pickaxe # WWDP remove duplicate
+      # - id: LavalandEquipmentExplorerSuit # WWDP disabled, buy in salvage vend
       - id: ShelterCapsule
-      - id: ClothingMaskGasExplorer
-      - id: FlashlightSeclite
+      # - id: ClothingMaskGasExplorer # WWDP remove duplicate
+      # - id: FlashlightSeclite # WWDP remove duplicate
       - id: ClothingEyesGlassesGarMeson
       # Lavaland Change End
 
@@ -50,7 +51,8 @@
       - id: SurvivalKnife
       - id: HandheldGPSBasic
       - id: RadioHandheld
-      - id: FlashlightSeclite
+      - id: FlashlightLantern # WWDP
+      - id: ClothingHandsGlovesColorBrown # WWDP
       - id: Pickaxe
       - id: ClothingShoesBootsWinterMiner #Delta V: Add departmental winter boots
       - id: JetpackMiniFilled # DeltaV - Salv lost their shuttle

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -103,7 +103,8 @@
       - id: RCDAmmo # Extra Compressed matter for the RPD
       - id: LunchboxEngineeringFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
-      - id: AccessConfigurator
+      - id: ClothingBeltUtilityAtmos # WWDP
+      # - id: AccessConfigurator # WWDP
 
 - type: entity
   id: LockerAtmosphericsFilled
@@ -125,7 +126,8 @@
       - id: RCDAmmo # Extra Compressed matter for the RPD
       - id: LunchboxEngineeringFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
-      - id: AccessConfigurator
+      - id: ClothingBeltUtilityAtmos # WWDP
+      # - id: AccessConfigurator # WWDP
 
 - type: entity
   id: LockerEngineerFilledHardsuit
@@ -142,7 +144,8 @@
       - id: RCDAmmo
       - id: LunchboxEngineeringFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
-      - id: AccessConfigurator
+      - id: ClothingBeltUtilityEngineering # WWDP
+      # - id: AccessConfigurator # WWDP
 
 - type: entity
   id: LockerEngineerFilled
@@ -159,7 +162,8 @@
       - id: RCDAmmo
       - id: LunchboxEngineeringFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
-      - id: AccessConfigurator
+      - id: ClothingBeltUtilityEngineering # WWDP
+      # - id: AccessConfigurator # WWDP
 
 - type: entity
   id: ClosetRadiationSuitFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -129,6 +129,7 @@
   - type: StorageFill
     contents:
       - id: ClothingOuterHardsuitEngineeringWhite
+      - id: ClothingBeltChiefEngineerFilled # WWDP
       - id: ClothingMaskBreath
       - id: ClothingEyesGlassesMeson
       - id: ClothingShoesBootsMagAdv

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -34,7 +34,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingOuterCoatCapTrench
+      - id: ClothingBeltSheathFilled # WWDP
+    # - id: ClothingOuterCoatCapTrench # WWDP
       - id: NukeDisk
       - id: PinpointerNuclear
       - id: CaptainIDCard
@@ -57,9 +58,11 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingOuterArmorCaptainCarapace # WWDP
+      # - id: ClothingOuterCoatCapTrench # WWDP
+      - id: ClothingBeltSheathFilled # WWDP
       - id: NukeDisk
       - id: PinpointerNuclear
+      - id: WeaponAntiqueLaser # WWDP
       - id: CaptainIDCard
       - id: CommsComputerCircuitboard
       - id: ClothingHeadsetAltCommand
@@ -79,7 +82,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingOuterArmorCaptainCarapace # WWDP
+      # - id: ClothingOuterCoatCapTrench # WWDP
       - id: NukeDisk
       - id: PinpointerNuclear
       - id: CaptainIDCard

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -312,8 +312,10 @@
   - type: StorageFill
     contents:
       - id: BoxBasicRegulatorLamp # wwdp edit
-      - id: ClothingEyesHudSecurity
+      - id: ClothingEyesGlassesSecurity # WWDP
     # - id: WeaponDisabler # WWDP
+      - id: AssballBat # WWDP
+      - id: ClothingHandsGlovesCombat # WWDP
       - id: ClothingOuterCoatHoSTrench
       - id: ClothingMaskNeckGaiter
       - id: ClothingOuterHardsuitSecurityRed # WWDP edit
@@ -321,7 +323,7 @@
       - id: OxygenTankFilled # WWDP edit
       - id: ClothingBeltSecurityFilled
       - id: ClothingHeadsetAltSecurity
-      - id: ClothingEyesGlassesSunglasses
+      # - id: ClothingEyesGlassesSunglasses # WWDP
       - id: ClothingShoesBootsJack
       - id: CigarRobustCase
         prob: 0.50
@@ -345,13 +347,15 @@
   - type: StorageFill
     contents:
       - id: BoxBasicRegulatorLamp # wwdp edit
-      - id: ClothingEyesHudSecurity
+      - id: ClothingEyesGlassesSecurity # WWDP
     # - id: WeaponDisabler # WWDP
+      - id: AssballBat # WWDP
+      - id: ClothingHandsGlovesCombat # WWDP
       - id: ClothingOuterCoatHoSTrench
       - id: ClothingMaskNeckGaiter
       - id: ClothingBeltSecurityFilled
       - id: ClothingHeadsetAltSecurity
-      - id: ClothingEyesGlassesSunglasses
+      # - id: ClothingEyesGlassesSunglasses # WWDP
       - id: ClothingShoesBootsJack
       - id: CigarGoldCase
         prob: 0.50

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -57,7 +57,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingOuterCoatCapTrench
+      - id: ClothingOuterArmorCaptainCarapace # WWDP
       - id: NukeDisk
       - id: PinpointerNuclear
       - id: CaptainIDCard
@@ -79,7 +79,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingOuterCoatCapTrench
+      - id: ClothingOuterArmorCaptainCarapace # WWDP
       - id: NukeDisk
       - id: PinpointerNuclear
       - id: CaptainIDCard

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -20,7 +20,7 @@
       - id: ClothingHeadsetAltCargo
       - id: BoxEncryptionKeyCargo
       - id: SpaceCashLuckyBill # DeltaV - LO steal objective, see Resources/Prototypes/DeltaV/Entities/Objects/Misc/first_bill.yml
-      - id: BoxPDACargo # Delta-V
+      # - id: BoxPDACargo # Delta-V # WWDP disabled
       - id: QuartermasterIDCard # Delta-V
       - id: AstroNavCartridge
       - id: LunchboxCommandFilledRandom # Delta-V Lunchboxes!
@@ -143,7 +143,7 @@
       - id: ClothingHeadsetAltEngineering
       - id: BoxEncryptionKeyEngineering
       - id: AccessConfigurator
-      - id: BoxPDAEngineering # Delta-V
+      # - id: BoxPDAEngineering # Delta-V # WWDP disabled
       - id: RCD
       - id: RCDAmmo
       - id: RPD
@@ -171,7 +171,7 @@
       - id: ClothingHeadsetAltEngineering
       - id: BoxEncryptionKeyEngineering
       - id: AccessConfigurator
-      - id: BoxPDAEngineering # Delta-V
+      # - id: BoxPDAEngineering # Delta-V # WWDP
       - id: CEIDCard # Delta-V
       - id: RCD
       - id: RCDAmmo
@@ -258,7 +258,7 @@
       - id: ClothingBeltUtilityFilled
       - id: RubberStampRd
       - id: BoxEncryptionKeyScience
-      - id: BoxPDAScience # Delta-V
+      # - id: BoxPDAScience # Delta-V # WWDP
       - id: RDIDCard # Delta-V
       - id: ClothingHeadsetAltScience
       - id: EncryptionKeyBinary
@@ -289,7 +289,7 @@
       - id: ClothingBeltUtilityFilled
       - id: RubberStampRd
       - id: BoxEncryptionKeyScience
-      - id: BoxPDAScience # Delta-V
+      # - id: BoxPDAScience # Delta-V # WWDP
       - id: RDIDCard # Delta-V
       - id: ClothingHeadsetAltScience
       - id: EncryptionKeyBinary
@@ -333,7 +333,7 @@
       - id: JetpackSecurityFilled
       - id: BoxEncryptionKeySecurity
       - id: HoloprojectorSecurity
-      - id: BoxPDASecurity # Delta-V
+      # - id: BoxPDASecurity # Delta-V # WWDP
       - id: HoSIDCard # Delta-V
       - id: LunchboxCommandFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
@@ -364,7 +364,7 @@
       - id: SecurityTechFabCircuitboard
       - id: BoxEncryptionKeySecurity
       - id: HoloprojectorSecurity
-      - id: BoxPDASecurity # Delta-V
+      # - id: BoxPDASecurity # Delta-V # WWDP
       - id: HoSIDCard # Delta-V
       - id: LunchboxCommandFilledRandom # Delta-V Lunchboxes!
         prob: 0.3

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -83,6 +83,7 @@
   - type: StorageFill
     contents:
       # - id: ClothingOuterCoatCapTrench # WWDP
+      - id: ClothingBeltSheathFilled # WWDP
       - id: NukeDisk
       - id: PinpointerNuclear
       - id: CaptainIDCard

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -270,7 +270,8 @@
       - id: AsimovCircuitBoard
       - id: AugustineCircuitBoard
       - id: CrewsimovCircuitBoard
-      - id: AntimovCircuitBoard
+      # - id: AntimovCircuitBoard # WWDP disabled
+      - id: ClothingEyesGlassesEpistemics # WWDP
       - id: BoxBodyBagRadiation # WD
       - id: PrinterDocFlatpack  # Corvax-Printer
 
@@ -296,12 +297,14 @@
       - id: LunchboxCommandFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
       - id: PsiWatchCartridge
+      - id: Intellicard # WWDP
       - id: StationAiUploadCircuitboard
       - id: AsimovCircuitBoard
       - id: AugustineCircuitBoard
       - id: CrewsimovCircuitBoard
-      - id: AntimovCircuitBoard
+      # - id: AntimovCircuitBoard # WWDP removed
       - id: BoxBodyBagRadiation # WD
+      - id: ClothingEyesGlassesEpistemics # WWDP
       - id: PrinterDocFlatpack  # Corvax-Printer
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -198,13 +198,14 @@
       - id: ClothingHeadHatBeretCmo
       - id: ClothingOuterHardsuitMedical
       - id: Hypospray
+      - id: OmnimedToolLite # WWDP
       - id: HandheldCrewMonitor
       - id: DoorRemoteMedical
       - id: RubberStampCMO
       - id: RubberStampPsychologist # DeltaV
       - id: MedicalTechFabCircuitboard
       - id: BoxEncryptionKeyMedical
-      - id: BoxPDAMedical # Delta-V
+      # - id: BoxPDAMedical # Delta-V # WWDP disabled
       - id: ClothingBeltMilitaryWebbingCMO # DeltaV - add webbing for CMO. ON THIS STATION, IT'S DRIP OR [die], CAPTAIN!
       - id: CMOIDCard # Delta-V
       - id: LunchboxCommandFilledRandom # Delta-V Lunchboxes!
@@ -226,12 +227,13 @@
       - id: ClothingHeadsetAltMedical
       - id: ClothingBackpackDuffelSurgeryFilled
       - id: Hypospray
+      - id: OmnimedToolLite # WWDP
       - id: HandheldCrewMonitor
       - id: DoorRemoteMedical
       - id: RubberStampCMO
       - id: MedicalTechFabCircuitboard
       - id: BoxEncryptionKeyMedical
-      - id: BoxPDAMedical # Delta-V
+      # - id: BoxPDAMedical # Delta-V # WWDP disabled
       - id: ClothingBeltMilitaryWebbingCMO # DeltaV - add webbing for CMO. ON THIS STATION, IT'S DRIP OR [die], CAPTAIN!
       - id: CMOIDCard # Delta-V
       - id: MedTekCartridge # Delta-v

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -164,11 +164,15 @@
       - id: BoxBottle
       - id: BoxVial
       - id: ChemBag
-      - id: ClothingHandsGlovesLatex
-      - id: ClothingHeadsetMedical
-      - id: ClothingMaskSterile
-      - id: HandLabeler
-        prob: 0.5
+      - id: Dropper # WWDP
+      - id: ClothingEyesGlassesChemist # WWDP
+      - id: ClothingEyesGlassesChemical # WWDP
+      - id: ClothingHandsGlovesChemist # WWDP
+      - id: ClothingOuterApronChemist # WWDP
+      - id: ClothingOuterCoatLabChemOpened # WWDP
+      # - id: ClothingHeadsetMedical # WWDP
+      - id: ClothingMaskBreathMedical # WWDP
+      - id: HandLabeler # WWDP 100% chance
 
 - type: entity
   id: LockerParamedicFilled #Delta V - Paramedic locker without suit
@@ -186,8 +190,12 @@
       - id: ClothingHeadsetMedical
       - id: ClothingMaskSterile
       - id: ClothingShoesBootsWinterParamedic #Delta V: Add departmental winter boots
-      - id: MedkitFilled
-        prob: 0.3
+      - id: ClothingBeltMedicalEMT # WWDP moved from starting kit
+      - id: HandheldGPSBasic # WWDP moved from starting kit
+      - id: HandheldCrewMonitor # WWDP moved from starting kit
+      - id: MedkitAdvancedFilled # WWDP
+      - id: FieldSurgeryKit # WWDP
+      - id: DefibrillatorCompact # WWDP
       - id: LunchboxMedicalFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
       - id: EmergencyNitrousOxideTankFilled
@@ -211,8 +219,11 @@
       - id: ClothingMaskSterile
       - id: ClothingShoesBootsWinterParamedic #Delta V: Add departmental winter boots
       - id: HandheldGPSBasic
-      - id: MedkitFilled
-        prob: 0.3
+      - id: ClothingBeltMedicalEMT # WWDP moved from starting kit
+      - id: HandheldCrewMonitor # WWDP moved from starting kit
+      - id: MedkitAdvancedFilled # WWDP
+      - id: FieldSurgeryKit # WWDP
+      - id: Portafib # WWDP
       - id: LunchboxMedicalFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
       - id: EmergencyNitrousOxideTankFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
@@ -9,8 +9,12 @@
       - id: ClothingHeadsetScience
       - id: ClothingMaskSterile
       - id: ClothingOuterCoatRnd
+      - id: ClothingOuterCoatLabOpened # WWDP
+      - id: ClothingBeltUtilityFilled # WWDP
+      - id: ClothingMaskGas # WWDP
       - id: AnomalyScanner
       - id: NodeScanner
+      - id: ClothingEyesHudEpistemics # WWDP
       - id: NetworkConfigurator
         prob: 0.5
       - id: LunchboxEpistemicsFilledRandom # Delta-V Lunchboxes!

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -12,9 +12,9 @@
     - id: ClothingBeltSecurityFilled
     - id: ClothingHandsGlovesKravMaga # Goobstation - Martial Arts
     - id: Flash
-    - id: ClothingEyesGlassesSunglasses
+    # - id: ClothingEyesGlassesSunglasses # WWDP
     - id: ClothingHeadsetAltSecurity
-    - id: ClothingHandsGlovesCombat
+    # - id: ClothingHandsGlovesCombat # WWDP
     - id: ClothingShoesBootsJack
     - id: ClothingOuterCoatWarden
     - id: ClothingOuterWinterWarden
@@ -23,7 +23,7 @@
     - id: ClothingOuterHardsuitWarden # WWDP edit
     - id: OxygenTankFilled # WWDP edit
     - id: HoloprojectorSecurity
-    - id: ClothingEyesHudSecurity
+    - id: ClothingEyesGlassesSecurity # WWDP
     - id: BoxPDAPrisoner # Delta-V
     - id: ClothingShoesBootsWinterWarden #Delta V: Add departmental winter boots
     - id: BoxEncryptionKeyPrisoner #Delta-V
@@ -46,16 +46,16 @@
     - id: ClothingBeltSecurityFilled
     - id: ClothingHandsGlovesKravMaga # Goobstation - Martial Arts
     - id: Flash
-    - id: ClothingEyesGlassesSunglasses
+    # - id: ClothingEyesGlassesSunglasses # WWDP
     - id: ClothingHeadsetAltSecurity
-    - id: ClothingHandsGlovesCombat
+    # - id: ClothingHandsGlovesCombat # WWDP
     - id: ClothingShoesBootsJack
     - id: ClothingOuterCoatWarden
     - id: ClothingOuterWinterWarden
     - id: RubberStampWarden
     - id: DoorRemoteArmory
     - id: HoloprojectorSecurity
-    - id: ClothingEyesHudSecurity
+    - id: ClothingEyesGlassesSecurity # WWDP
     - id: BoxPDAPrisoner # Delta-V
     - id: ClothingShoesBootsWinterWarden #Delta V: Add departmental winter boots
     - id: BoxEncryptionKeyPrisoner #Delta-V
@@ -103,6 +103,10 @@
       amount: 2
     ##      - id: ClothingOuterHardsuitCombatCorpsman # DeltaV - ClothingOuterHardsuitBrigmedic replaced in favour of corpsman's combat hardsuit; removing from standard filled locker to place in hardsuit filled locker.
     - id: BoxSterileMask
+    - id: ClothingHandsGlovesNitrile # WWDP
+    - id: ClothingBeltCorpsmanWebbing # WWDP
+    - id: FieldSurgeryKit # WWDP
+    - id: DefibrillatorCompact # WWDP
     - id: ClothingHeadHatBeretCorpsman # DeltaV - ClothingHeadHatBeretBrigmedic replaced in favour of corpsman beret.
     ##      - id: ClothingOuterCoatAMG # DeltaV - removed until I can resprite it or replace it.
     - id: ClothingUniformJumpsuitBrigmedic
@@ -146,6 +150,10 @@
     - id: OxygenTankFilled # WWDP edit
     - id: ClothingUniformJumpsuitBrigmedic
     - id: ClothingUniformJumpskirtBrigmedic
+    - id: ClothingHandsGlovesNitrile # WWDP
+    - id: ClothingBeltCorpsmanWebbing # WWDP
+    - id: FieldSurgeryKit # WWDP
+    - id: DefibrillatorCompact # WWDP
     - id: HandheldGPSBasic # Added GPS because I just think it should be there tbh.
     - id: MedkitFilled
     - id: MedkitCombatFilled
@@ -173,8 +181,7 @@
   components:
   - type: StorageFill
     contents:
-    - id: ClothingEyesHudSecurity
-      prob: 0.3
+    - id: ClothingEyesGlassesSecurity # WWDP
     - id: ClothingHeadHatFedoraBrown
     - id: ClothingNeckTieDet
     - id: ClothingOuterVestDetective

--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -9,7 +9,7 @@
       - id: ClothingEyesHudBeer
       - id: WeaponShotgunDoubleBarreledRubber # WWDP its so back
       - id: BoxBeanbag # WWDP
-      - id: SpaceCash5000 # WWDP
+      - id: SpaceCash1000 # WWDP
       - id: HandLabeler
         amount: 1
       - id: DrinkBottleBeer
@@ -34,7 +34,7 @@
       - id: ClothingEyesHudBeer
       - id: WeaponShotgunDoubleBarreledRubber # WWDP its so back
       - id: BoxBeanbag # WWDP
-      - id: SpaceCash5000 # WWDP
+      - id: SpaceCash1000 # WWDP
       - id: HandLabeler
         amount: 1
       - id: DrinkBottleBeer

--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -7,6 +7,9 @@
     contents:
       - id: DrinkShaker
       - id: ClothingEyesHudBeer
+      - id: WeaponShotgunDoubleBarreledRubber # WWDP its so back
+      - id: BoxBeanbag # WWDP
+      - id: SpaceCash5000 # WWDP
       - id: HandLabeler
         amount: 1
       - id: DrinkBottleBeer
@@ -29,6 +32,9 @@
     contents:
       - id: DrinkShaker
       - id: ClothingEyesHudBeer
+      - id: WeaponShotgunDoubleBarreledRubber # WWDP its so back
+      - id: BoxBeanbag # WWDP
+      - id: SpaceCash5000 # WWDP
       - id: HandLabeler
         amount: 1
       - id: DrinkBottleBeer

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -145,7 +145,7 @@
     - id: ClothingMaskBreath
       amount: 1 #Delta-V Double the masks # WWDP - no
     - id: ClothingShoesBootsMagSec
-      amount: 2
+      amount: 1 # WWDP
   - type: AccessReader
     access: [["Security"]]
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -7,14 +7,15 @@
     Bloodpack: 5
     EpinephrineChemistryBottle: 3
     Syringe: 5
-    Portafib: 1
+    Defibrillator: 1 # WWDP
+    EmergencyRollerBedSpawnFolded: 1 # WWDP
     # WD EDIT START
     #ClothingEyesGlasses: 5
     #ClothingEyesHudMedical: 2
     #ClothingEyesEyepatchHudMedical: 2
     # WD EDIT END
     VehicleWheelchairFolded: 3 # Goobstation - Vehicles
-    ClothingShoesBootsWinterAtmos: 2 #Delta V: Add departmental winter boots
+    # ClothingShoesBootsWinterAtmos: 2 #Delta V: Add departmental winter boots # WWDP removed - wtf?
   #WWDP edit start
   emaggedInventory:
     StimpackMini: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/robodrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/robodrobe.yml
@@ -4,6 +4,7 @@
     ClothingOuterCoatRobo: 2
     ClothingUniformJumpsuitRoboticist: 2
     ClothingUniformJumpskirtRoboticist: 2
+    ClothingEyesHudDiagnostic: 2 # WWDP
     ClothingShoesColorBlack: 2
     ClothingHandsGlovesRobohands: 2
     ClothingHeadHatCorpsoft: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -15,10 +15,11 @@
     HoloprojectorSecurity: 5 # WD - moved from Sec lockers
     ClothingEyesGlassesSunglasses: 2
     ClothingEyesGlassesSecurity: 2 # WD - SecHuds
-    ClothingEyesHudSecurity: 2
-    ClothingEyesEyepatchHudSecurity: 2
+    # ClothingEyesHudSecurity: 2 # WWDP remove bloat
+    # ClothingEyesEyepatchHudSecurity: 2
     ClothingBeltSecurityWebbing: 5
     CombatKnife: 3
+    Truncheon: 2 # WWDP
     Zipties: 12
     BolaEnergy: 6
     RiotShield: 2
@@ -26,7 +27,7 @@
     RiotBulletShield: 2
     RadioHandheldSecurity: 5
     # WD - armor moved to SecDrobe
-    BreachingCharge: 8
+    BreachingCharge: 4 # WWDP less boom boom
   # security officers need to follow a diet regimen!
   contrabandInventory:
     FoodDonutHomer: 12

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
@@ -34,5 +34,5 @@
     ClothingUniformJumpskirtSecGrey: 3
     ClothingUniformJumpsuitSecBlue: 3
     ClothingUniformJumpskirtSecBlue: 3 # DeltaV - new skirt sprited, added to secdrobe
-    Truncheon: 1
+    # Truncheon: 1 # WWDP moved to sectech
 # WD edit end

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Command/captain.yml
@@ -152,3 +152,5 @@
       id: LoadoutCommandCapJumpsuitFormal
     - type: loadout
       id: LoadoutCommandCapJumpskirtFormal
+    - type: loadout
+      id: LoadoutCommandCapJumpsuitCommand

--- a/Resources/Prototypes/DeltaV/Catalog/Fills/Backpacks/StarterGear/backpack.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/Fills/Backpacks/StarterGear/backpack.yml
@@ -30,6 +30,10 @@
   - type: StorageFill
     contents:
       - id: RubberStampPsychologist
+      - id: PillCanisterSpaceDrugs
+      - id: PillCanisterPax
+      - id: PillCanisterCryptobiolin
+      - id: PillCanisterChloralHydrate
 
 
 - type: entity

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
@@ -60,18 +60,18 @@
   - CorpsmanPlasmamanGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitBrigmedic
-    outerClothing: ClothingOuterArmorPlateCarrier
-    back: ClothingBackpackBrigmedicFilled
-    shoes: ClothingShoesBootsCombatFilled
-    gloves: ClothingHandsGlovesNitrile
-    eyes: ClothingEyesHudMedical
+    # outerClothing: ClothingOuterArmorPlateCarrier # WWDP
+    back: ClothingBackpackBrigmedic
+    shoes: ClothingShoesBootsJack # WWDP
+    # gloves: ClothingHandsGlovesNitrile # WWDP
+    # eyes: ClothingEyesHudMedical # WWDP
     head: ClothingHeadHatBeretCorpsman
     id: CorpsmanPDA
     ears: ClothingHeadsetBrigmedic
-    belt: ClothingBeltCorpsmanWebbingFilled
+    # belt: ClothingBeltCorpsmanWebbingFilled # WWDP
   innerClothingSkirt: ClothingUniformJumpskirtBrigmedic
-  satchel: ClothingBackpackSatchelBrigmedicFilled
-  duffelbag: ClothingBackpackDuffelBrigmedicFilled
+  satchel: ClothingBackpackSatchelBrigmedic
+  duffelbag: ClothingBackpackDuffelBrigmedic
 
 - type: startingGear
   id: CorpsmanPlasmamanGear

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/telescopic_baton.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/telescopic_baton.yml
@@ -63,7 +63,7 @@
         enum.TelescopicBatonVisuals.Layer:
           True: { state: icon }
           False: { state: icon-off }
-  - type: Clothing
+  - type: Clothing # WWDP
     quickEquip: false
     slots:
     - Belt

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/telescopic_baton.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/telescopic_baton.yml
@@ -28,6 +28,11 @@
     activatedDamage:
       types:
         Blunt: 6 # WWDP EDIT
+    activatedSoundOnHit: # WWDP
+      path: /Audio/Effects/snap.ogg
+      params:
+        pitch: 0.2
+        variation: 0.5
   - type: ItemToggleDamageOtherOnHit
   - type: ItemToggleSize
     activatedSize: Normal
@@ -43,6 +48,7 @@
   - type: MeleeWeapon
     attackRate: 1 # WWDP
     bluntStaminaDamageFactor: 4.5 # WWDP, 4 hits to stun
+    animationRotation: -45 # WWDP
     maxTargets: 1
     canHeavyAttack: false
     damage:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/telescopic_baton.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/telescopic_baton.yml
@@ -63,6 +63,10 @@
         enum.TelescopicBatonVisuals.Layer:
           True: { state: icon }
           False: { state: icon-off }
+  - type: Clothing
+    quickEquip: false
+    slots:
+    - Belt
 
 - type: entity
   parent: TelescopicBaton

--- a/Resources/Prototypes/Loadouts/Generic/eyes.yml
+++ b/Resources/Prototypes/Loadouts/Generic/eyes.yml
@@ -196,8 +196,9 @@
       - Security
       - Command
     - !type:CharacterJobRequirement
+      inverted: true
       jobs:
-      - Brigmedic
+      - Prisoner
     # WD EDIT END
 
 - type: loadout
@@ -217,8 +218,9 @@
       - Security
       - Command
     - !type:CharacterJobRequirement
+      inverted: true
       jobs:
-      - Brigmedic
+      - Prisoner
   # WD EDIT END
 
 - type: loadout
@@ -237,10 +239,11 @@
       - Security
       - Command
     - !type:CharacterJobRequirement
+      inverted: true
       jobs:
-      - Brigmedic
+      - Prisoner
   # WD EDIT END
-  
+
 - type: loadout
   id: LoadoutEyesGlassesSunglassesVisor
   category: Eyes
@@ -257,10 +260,12 @@
       - Security
       - Command
     - !type:CharacterJobRequirement
+      inverted: true
       jobs:
       - Brigmedic
+      - Prisoner
   # WD EDIT END
-  
+
 - type: loadout
   id: LoadoutItemBlindfoldFake
   category: Eyes

--- a/Resources/Prototypes/Loadouts/Generic/hands.yml
+++ b/Resources/Prototypes/Loadouts/Generic/hands.yml
@@ -107,19 +107,19 @@
       group: LoadoutGloves
   items:
     - ClothingClothWrap
-
-- type: loadout
-  id: ClothingHandsTacticalMaidGlovesLoadout
-  category: Hands
-  cost: 0
-  exclusive: true
-  items:
-    - ClothingHandsTacticalMaidGlovesLoadout
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutGloves
-
-# WD EDIT START
+    -
+# WWDP EDIT START
+# - type: loadout
+#   id: ClothingHandsTacticalMaidGlovesLoadout
+#   category: Hands
+#   cost: 0
+#   exclusive: true
+#   items:
+#     - ClothingHandsTacticalMaidGlovesLoadout
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutGloves
+#
 # - type: loadout
 #   id: ClothingHandsGlovesCombatTCAF
 #   category: Hands
@@ -137,4 +137,4 @@
 #         - WarVet
 #   items:
 #     - ClothingHandsGlovesCombatTCAF
-# WD EDIT END
+# WWDP EDIT END

--- a/Resources/Prototypes/Loadouts/Generic/hands.yml
+++ b/Resources/Prototypes/Loadouts/Generic/hands.yml
@@ -107,7 +107,7 @@
       group: LoadoutGloves
   items:
     - ClothingClothWrap
-    -
+
 # WWDP EDIT START
 # - type: loadout
 #   id: ClothingHandsTacticalMaidGlovesLoadout

--- a/Resources/Prototypes/Loadouts/Generic/items.yml
+++ b/Resources/Prototypes/Loadouts/Generic/items.yml
@@ -496,6 +496,7 @@
        inverted: true
        jobs:
          - Clown
+         - Prisoner # WWDP
     - !type:CharacterItemGroupRequirement
       group: LoadoutBoxKits
 
@@ -526,6 +527,7 @@
        inverted: true
        jobs:
          - Brigmedic
+         - Prisoner # WWDP
     - !type:CharacterItemGroupRequirement
       group: LoadoutBoxKits
 
@@ -722,6 +724,7 @@
     - !type:CharacterJobRequirement
        jobs:
          - Brigmedic
+         - Prisoner # WWDP
 
  # 5 zillion ghostroles, more people will take them if theyre less common.
  # - type: loadout

--- a/Resources/Prototypes/Loadouts/Generic/items.yml
+++ b/Resources/Prototypes/Loadouts/Generic/items.yml
@@ -305,97 +305,101 @@
         - Musician
 
 # Survival Kit
-- type: loadout
-  id: LoadoutItemsEmergencyOxygenTank
-  category: Items
-  cost: 0
-  items:
-    - EmergencyOxygenTankFilled
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAirTank
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Plasmaman
 
-- type: loadout
-  id: LoadoutItemsExtendedEmergencyOxygenTank
-  category: Items
-  cost: 1
-  items:
-    - ExtendedEmergencyOxygenTankFilled
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAirTank
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Plasmaman
-
-- type: loadout
-  id: LoadoutItemsDoubleEmergencyOxygenTank
-  category: Items
-  cost: 2
-  items:
-    - DoubleEmergencyOxygenTankFilled
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAirTank
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Plasmaman
-
-- type: loadout
-  id: LoadoutItemClothingMaskBreath
-  category: Items
-  cost: 0
-  items:
-    - ClothingMaskBreath
-
-- type: loadout
-  id: LoadoutItemsEmergencyCrowbar
-  category: Items
-  cost: 3
-  canBeHeirloom: true
-  items:
-    - CrowbarRed
-
-- type: loadout
-  id: LoadoutItemFireExtinguisher
-  category: Items
-  cost: 3
-  items:
-    - FireExtinguisher
-
-- type: loadout
-  id: LoadoutItemFlashlightLantern
-  category: Items
-  cost: 2
-  items:
-    - FlashlightLantern
-
-- type: loadout
-  id: LoadoutItemFlare
-  category: Items
-  cost: 1
-  items:
-    - Flare
-
-- type: loadout
-  id: LoadoutEmergencyMedipen
-  category: Items
-  cost: 1
-  items:
-    - EmergencyMedipen
-
-- type: loadout
-  id: LoadoutSpaceMedipen
-  category: Items
-  cost: 1
-  items:
-    - SpaceMedipen
+# WWDP edit start - just take the full survival kit at this point
+# - type: loadout
+#   id: LoadoutItemsEmergencyOxygenTank
+#   category: Items
+#   cost: 0
+#   items:
+#     - EmergencyOxygenTankFilled
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAirTank
+#     - !type:CharacterSpeciesRequirement
+#       inverted: true
+#       species:
+#         - Plasmaman
+#
+# - type: loadout
+#   id: LoadoutItemsExtendedEmergencyOxygenTank
+#   category: Items
+#   cost: 1
+#   items:
+#     - ExtendedEmergencyOxygenTankFilled
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAirTank
+#     - !type:CharacterSpeciesRequirement
+#       inverted: true
+#       species:
+#         - Plasmaman
+#
+# - type: loadout
+#   id: LoadoutItemsDoubleEmergencyOxygenTank
+#   category: Items
+#   cost: 2
+#   items:
+#     - DoubleEmergencyOxygenTankFilled
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAirTank
+#     - !type:CharacterSpeciesRequirement
+#       inverted: true
+#       species:
+#         - Plasmaman
+#
+# - type: loadout
+#   id: LoadoutItemClothingMaskBreath
+#   category: Items
+#   cost: 0
+#   items:
+#     - ClothingMaskBreath
+#
+# - type: loadout
+#   id: LoadoutItemsEmergencyCrowbar
+#   category: Items
+#   cost: 3
+#   canBeHeirloom: true
+#   items:
+#     - CrowbarRed
+#
+# - type: loadout
+#   id: LoadoutItemFireExtinguisher
+#   category: Items
+#   cost: 3
+#   items:
+#     - FireExtinguisher
+#
+# - type: loadout
+#   id: LoadoutItemFlashlightLantern
+#   category: Items
+#   cost: 2
+#   items:
+#     - FlashlightLantern
+#
+# - type: loadout
+#   id: LoadoutItemFlare
+#   category: Items
+#   cost: 1
+#   items:
+#     - Flare
+#
+# - type: loadout
+#   id: LoadoutEmergencyMedipen
+#   category: Items
+#   cost: 1
+#   items:
+#     - EmergencyMedipen
+#
+# - type: loadout
+#   id: LoadoutSpaceMedipen
+#   category: Items
+#   cost: 1
+#   items:
+#     - SpaceMedipen
+#
+# WWDP edit end
 
 # Paperwork
 - type: loadout
@@ -571,131 +575,136 @@
       group: LoadoutBoxKits
 
 # Medkits
-- type: loadout
-  id: LoadoutMedkitFilled
-  category: Items
-  cost: 2
-  items:
-    - MedkitFilled
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMedkits
 
-- type: loadout
-  id: LoadoutMedkitBruteFilled
-  category: Items
-  cost: 2
-  items:
-    - MedkitBruteFilled
-  requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - MedicalDoctor
-        - Paramedic
-        - ChiefMedicalOfficer
-        - MedicalIntern
-        - Brigmedic
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMedkits
+# WWDP edit start - disabled
+# - type: loadout
+#   id: LoadoutMedkitFilled
+#   category: Items
+#   cost: 2
+#   items:
+#     - MedkitFilled
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMedkits
+#
+# - type: loadout
+#   id: LoadoutMedkitBruteFilled
+#   category: Items
+#   cost: 2
+#   items:
+#     - MedkitBruteFilled
+#   requirements:
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - MedicalDoctor
+#         - Paramedic
+#         - ChiefMedicalOfficer
+#         - MedicalIntern
+#         - Brigmedic
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMedkits
+#
+# - type: loadout
+#   id: LoadoutMedkitBurnFilled
+#   category: Items
+#   cost: 2
+#   items:
+#     - MedkitBurnFilled
+#   requirements:
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - MedicalDoctor
+#         - Paramedic
+#         - ChiefMedicalOfficer
+#         - MedicalIntern
+#         - Brigmedic
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMedkits
+#
+# - type: loadout
+#   id: LoadoutMedkitToxinFilled
+#   category: Items
+#   cost: 2
+#   items:
+#     - MedkitToxinFilled
+#   requirements:
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - MedicalDoctor
+#         - Paramedic
+#         - ChiefMedicalOfficer
+#         - MedicalIntern
+#         - Brigmedic
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMedkits
+#
+# - type: loadout
+#   id: LoadoutMedkitOxygenFilled
+#   category: Items
+#   cost: 2
+#   items:
+#     - MedkitOxygenFilled
+#   requirements:
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - MedicalDoctor
+#         - Paramedic
+#         - ChiefMedicalOfficer
+#         - MedicalIntern
+#         - Brigmedic
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMedkits
+#
+# - type: loadout
+#   id: LoadoutMedkitRadiationFilled
+#   category: Items
+#   cost: 2
+#   items:
+#     - MedkitRadiationFilled
+#   requirements:
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - MedicalDoctor
+#         - Paramedic
+#         - ChiefMedicalOfficer
+#         - MedicalIntern
+#         - Brigmedic
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMedkits
+#
+# - type: loadout
+#   id: LoadoutMedkitAdvancedFilled
+#   category: Items
+#   cost: 3
+#   items:
+#     - MedkitAdvancedFilled
+#   requirements:
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - MedicalDoctor
+#         - Paramedic
+#         - ChiefMedicalOfficer
+#         - MedicalIntern
+#         - Brigmedic
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMedkits
+#
+# - type: loadout
+#   id: LoadoutMedkitCombatFilled
+#   category: Items
+#   cost: 3
+#   items:
+#     - MedkitCombatFilled
+#   requirements:
+#     - !type:CharacterJobRequirement
+#        jobs:
+#          - ChiefMedicalOfficer
+#          - Brigmedic
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMedkits
+#
+# WWDP edit end
 
-- type: loadout
-  id: LoadoutMedkitBurnFilled
-  category: Items
-  cost: 2
-  items:
-    - MedkitBurnFilled
-  requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - MedicalDoctor
-        - Paramedic
-        - ChiefMedicalOfficer
-        - MedicalIntern
-        - Brigmedic
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMedkits
-
-- type: loadout
-  id: LoadoutMedkitToxinFilled
-  category: Items
-  cost: 2
-  items:
-    - MedkitToxinFilled
-  requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - MedicalDoctor
-        - Paramedic
-        - ChiefMedicalOfficer
-        - MedicalIntern
-        - Brigmedic
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMedkits
-
-- type: loadout
-  id: LoadoutMedkitOxygenFilled
-  category: Items
-  cost: 2
-  items:
-    - MedkitOxygenFilled
-  requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - MedicalDoctor
-        - Paramedic
-        - ChiefMedicalOfficer
-        - MedicalIntern
-        - Brigmedic
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMedkits
-
-- type: loadout
-  id: LoadoutMedkitRadiationFilled
-  category: Items
-  cost: 2
-  items:
-    - MedkitRadiationFilled
-  requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - MedicalDoctor
-        - Paramedic
-        - ChiefMedicalOfficer
-        - MedicalIntern
-        - Brigmedic
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMedkits
-
-- type: loadout
-  id: LoadoutMedkitAdvancedFilled
-  category: Items
-  cost: 3
-  items:
-    - MedkitAdvancedFilled
-  requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - MedicalDoctor
-        - Paramedic
-        - ChiefMedicalOfficer
-        - MedicalIntern
-        - Brigmedic
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMedkits
-
-- type: loadout
-  id: LoadoutMedkitCombatFilled
-  category: Items
-  cost: 3
-  items:
-    - MedkitCombatFilled
-  requirements:
-    - !type:CharacterJobRequirement
-       jobs:
-         - ChiefMedicalOfficer
-         - Brigmedic
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMedkits
 
 #Misc Items
 # - type: loadout # WWDP disabled (xd)
@@ -711,20 +720,21 @@
 #   items:
 #   - WeaponCivilianDisabler
 
-- type: loadout
-  id: LoadoutItemFlash
-  category: Items
-  cost: 1
-  items:
-    - Flash
-  requirements:
-    - !type:CharacterDepartmentRequirement
-       departments:
-         - Security
-    - !type:CharacterJobRequirement
-       jobs:
-         - Brigmedic
-         - Prisoner # WWDP
+# WWDP, removed duplicate
+# - type: loadout
+#   id: LoadoutItemFlash
+#   category: Items
+#   cost: 1
+#   items:
+#     - Flash
+#   requirements:
+#     - !type:CharacterDepartmentRequirement
+#        departments:
+#          - Security
+#     - !type:CharacterJobRequirement
+#        jobs:
+#          - Brigmedic
+#          - Prisoner # WWDP
 
  # 5 zillion ghostroles, more people will take them if theyre less common.
  # - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Command/admin_assistant.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/admin_assistant.yml
@@ -1,80 +1,84 @@
-# Uncategorized
-# Backpacks
-
-# Belt
-
-# Ears
-
-# Equipment
-
-# Eyes
-
-# Gloves
-- type: loadout
-  id: LoadoutAdministrativeAssistantGlovesHoP
-  category: JobsCommandAdminAssistant
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAdminAssistantGloves
-    - !type:CharacterJobRequirement
-      jobs:
-        - AdministrativeAssistant
-  items:
-    - ClothingHandsGlovesHop
-
-- type: loadout
-  id: LoadoutAdministrativeAssistantGlovesInspection
-  category: JobsCommandAdminAssistant
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAdminAssistantGloves
-    - !type:CharacterJobRequirement
-      jobs:
-        - AdministrativeAssistant
-  items:
-    - ClothingHandsGlovesInspection
-
-# Head
-
-# Id
-
-# Neck
-
-# Mask
-
-# Outer
-
-# Shoes
-
-# Uniforms
-- type: loadout
-  id: LoadoutAdminAssistantUniformJumpsuit
-  category: JobsCommandAdminAssistant
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAdminAssistantUniforms
-    - !type:CharacterJobRequirement
-      jobs:
-        - AdministrativeAssistant
-  items:
-    - ClothingUniformJumpsuitAdminAssistant
-
-- type: loadout
-  id: LoadoutAdminAssistantUniformJumpskirt
-  category: JobsCommandAdminAssistant
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAdminAssistantUniforms
-    - !type:CharacterJobRequirement
-      jobs:
-        - AdministrativeAssistant
-  items:
-    - ClothingUniformJumpskirtAdminAssistant
+# WWDP EDIT START -  role removed
+#
+# # Uncategorized
+# # Backpacks
+#
+# # Belt
+#
+# # Ears
+#
+# # Equipment
+#
+# # Eyes
+#
+# # Gloves
+# - type: loadout
+#   id: LoadoutAdministrativeAssistantGlovesHoP
+#   category: JobsCommandAdminAssistant
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAdminAssistantGloves
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - AdministrativeAssistant
+#   items:
+#     - ClothingHandsGlovesHop
+#
+# - type: loadout
+#   id: LoadoutAdministrativeAssistantGlovesInspection
+#   category: JobsCommandAdminAssistant
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAdminAssistantGloves
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - AdministrativeAssistant
+#   items:
+#     - ClothingHandsGlovesInspection
+#
+# # Head
+#
+# # Id
+#
+# # Neck
+#
+# # Mask
+#
+# # Outer
+#
+# # Shoes
+#
+# # Uniforms
+# - type: loadout
+#   id: LoadoutAdminAssistantUniformJumpsuit
+#   category: JobsCommandAdminAssistant
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAdminAssistantUniforms
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - AdministrativeAssistant
+#   items:
+#     - ClothingUniformJumpsuitAdminAssistant
+#
+# - type: loadout
+#   id: LoadoutAdminAssistantUniformJumpskirt
+#   category: JobsCommandAdminAssistant
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAdminAssistantUniforms
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - AdministrativeAssistant
+#   items:
+#     - ClothingUniformJumpskirtAdminAssistant
+#
+# WWDP EDIT END

--- a/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
@@ -1,382 +1,386 @@
-# Uncategorized
-# Backpacks
-- type: loadout
-  id: LoadoutClothingBackpackBlueshield
-  category: JobsCommandBlueshieldOfficer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBlueshieldOfficerBackpacks
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - ClothingBackpackBlueshield
-
-- type: loadout
-  id: LoadoutClothingSatchelBlueshield
-  category: JobsCommandBlueshieldOfficer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBlueshieldOfficerBackpacks
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - ClothingBackpackSatchelBlueshield
-
-- type: loadout
-  id: LoadoutClothingDuffelBlueshield
-  category: JobsCommandBlueshieldOfficer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBlueshieldOfficerBackpacks
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - ClothingBackpackDuffelBlueshield
-
-- type: loadout
-  id: LoadoutClothingModsuitBlueshield
-  category: JobsCommandBlueshieldOfficer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBlueshieldOfficerBackpacks
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - ClothingModsuitPraetorian #Blueshield modsuit
-
-
-# Belt
-
-# Ears
-
-# Equipment
-- type: loadout
-  id: LoadoutBSOEnergyRevolver
-  category: JobsCommandBlueshieldOfficer
-  cost: 0
-  canBeHeirloom: true
-  guideEntry: SecurityWeapons
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSecurityWeapons
-    - !type:CharacterDepartmentTimeRequirement
-      department: Security
-      min: 18000 # 5 hours
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-    - !type:CharacterAgeRequirement
-      min: 21
-  items:
-    - WeaponEnergyRevolverSecurity
-
-- type: loadout
-  id: LoadoutBSORifleChester
-  category: JobsCommandBlueshieldOfficer
-  cost: 0
-  canBeHeirloom: true
-  guideEntry: SecurityWeapons
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBlueshieldOfficerPrimary
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-    - !type:CharacterAgeRequirement
-      min: 21
-  items:
-    - WeaponLeverChester
-    - BlueshieldAmmunitionBoxFilled
-
-- type: loadout
-  id: LoadoutBSORifleBRDIR25
-  category: JobsCommandBlueshieldOfficer
-  cost: 9 # Significant upgrade over a Chester, offered here for the STYLE. Intentionally priced at you not being able to buy all 3 medical items alongside it, plus being unable to buy it alongside the CQC Manual.
-  canBeHeirloom: true
-  guideEntry: SecurityWeapons
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBlueshieldOfficerPrimary
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-    - !type:CharacterAgeRequirement
-      min: 21
-  items:
-    - WeaponSubMachineGunBRDIR25BSO # The Den sprites
-
-- type: loadout
-  id: LoadoutBSOGreatShield
-  category: JobsCommandBlueshieldOfficer
-  cost: 0
-  canBeHeirloom: true
-  guideEntry: SecurityWeapons
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBlueshieldOfficerPrimary
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-    - !type:CharacterAgeRequirement
-      min: 21
-  items:
-    - BlueShieldShieldFilled
-
-- type: loadout
-  id: LoadoutBSOMedkitCombatFilled
-  category: JobsCommandBlueshieldOfficer
-  cost: 2
-  requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - MedkitCombatFilled
-
-- type: loadout
-  id: LoadoutBSOPortafib
-  category: JobsCommandBlueshieldOfficer
-  cost: 2
-  requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - Portafib
-
-- type: loadout
-  id: LoadoutBSOCrewMonitor
-  category: JobsCommandBlueshieldOfficer
-  cost: 2 # BSO's main job is to keep command safe, they should be able to monitor their status & location without that costing too many points.
-  requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - HandheldCrewMonitor
-
-- type: loadout
-  id: LoadoutBSOCQCManual
-  category: JobsCommandBlueshieldOfficer
-  cost: 8 # You can run this alongside the 3 medical items, but then you will be restricted to free gear for everything else such as weapons or other utilities.
-  requirements: # Knowledge does not occupy a weapon slot. You are a trained bodyguard, so it makes sense to have it. Balanced out by costing over half of your loadout points.
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - BSOManual
-
-- type: loadout
-  id: LoadoutBSOTerminus
-  category: JobsCommandBlueshieldOfficer
-  cost: 0
-  canBeHeirloom: true
-  guideEntry: SecurityWeapons
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBlueshieldOfficerPrimary
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-    - !type:CharacterAgeRequirement
-      min: 21
-    - !type:CharacterSpeciesRequirement
-      species:
-      - Oni
-  items:
-    - Terminus
-
-# Eyes
-
-# Gloves
-
-# Head
-- type: loadout
-  id: LoadoutClothingBlueshieldBeretNavy
-  category: JobsCommandBlueshieldOfficer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBlueshieldOfficerHats
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - ClothingHeadHatBeretNavy
-
-- type: loadout
-  id: LoadoutClothingBlueshieldBeretOfficer
-  category: JobsCommandBlueshieldOfficer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBlueshieldOfficerHats
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - ClothingHeadHatBeretOfficer
-
-- type: loadout
-  id: LoadoutClothingBlueshieldCowboyHat
-  category: JobsCommandBlueshieldOfficer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBlueshieldOfficerHats
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - ClothingHeadHatCowboyBlueshield
-
-# Id
-
-# Neck
-
-# Mask
-
-# Outer
-- type: loadout
-  id: LoadoutClothingBlueshieldArmoredJacket
-  category: JobsCommandBlueshieldOfficer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBlueshieldOfficerVests
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - ClothingBlueshieldArmoredJacket
-
-- type: loadout
-  id: LoadoutClothingBlueshieldArmoredCowboyJacket
-  category: JobsCommandBlueshieldOfficer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBlueshieldOfficerVests
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - ClothingBlueshieldArmoredCowboyJacket
-
-- type: loadout
-  id: LoadoutClothingBlueshieldArmorVest
-  category: JobsCommandBlueshieldOfficer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBlueshieldOfficerVests
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - ClothingBlueshieldArmourVest
-
-- type: loadout
-  id: LoadoutClothingBlueshieldArmoredMarine
-  category: JobsCommandBlueshieldOfficer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBlueshieldOfficerVests
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - ClothingBlueshieldArmoredMarine
-
-- type: loadout
-  id: LoadoutClothingBlueshieldArmoredVest
-  category: JobsCommandBlueshieldOfficer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBlueshieldOfficerVests
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - ClothingBlueshieldArmoredVest
-
-- type: loadout
-  id: LoadoutClothingBlueshieldArmoredKimono
-  category: JobsCommandBlueshieldOfficer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBlueshieldOfficerVests
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - ClothingBlueshieldArmoredKimono
-
-- type: loadout
-  id: LoadoutClothingBlueshieldArmoredCoat
-  category: JobsCommandBlueshieldOfficer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBlueshieldOfficerVests
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - ClothingBlueshieldArmoredCoat
-
-# Shoes
-
-# Uniforms
-- type: loadout
-  id: LoadoutClothingUniformJumpskirtBlueshieldOfficer
-  category: JobsCommandBlueshieldOfficer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBlueshieldOfficerUniforms
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - ClothingUniformJumpskirtBlueshieldOfficer
-
-- type: loadout
-  id: LoadoutClothingUniformJumpsuitBlueshieldOfficer
-  category: JobsCommandBlueshieldOfficer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBlueshieldOfficerUniforms
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - ClothingUniformJumpsuitBlueshieldOfficer
+# WWDP EDIT - disabled (role removed)
+#
+# # Uncategorized
+# # Backpacks
+# - type: loadout
+#   id: LoadoutClothingBackpackBlueshield
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBlueshieldOfficerBackpacks
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - ClothingBackpackBlueshield
+#
+# - type: loadout
+#   id: LoadoutClothingSatchelBlueshield
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBlueshieldOfficerBackpacks
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - ClothingBackpackSatchelBlueshield
+#
+# - type: loadout
+#   id: LoadoutClothingDuffelBlueshield
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBlueshieldOfficerBackpacks
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - ClothingBackpackDuffelBlueshield
+#
+# - type: loadout
+#   id: LoadoutClothingModsuitBlueshield
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBlueshieldOfficerBackpacks
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - ClothingModsuitPraetorian #Blueshield modsuit
+#
+#
+# # Belt
+#
+# # Ears
+#
+# # Equipment
+# - type: loadout
+#   id: LoadoutBSOEnergyRevolver
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 0
+#   canBeHeirloom: true
+#   guideEntry: SecurityWeapons
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSecurityWeapons
+#     - !type:CharacterDepartmentTimeRequirement
+#       department: Security
+#       min: 18000 # 5 hours
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#     - !type:CharacterAgeRequirement
+#       min: 21
+#   items:
+#     - WeaponEnergyRevolverSecurity
+#
+# - type: loadout
+#   id: LoadoutBSORifleChester
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 0
+#   canBeHeirloom: true
+#   guideEntry: SecurityWeapons
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBlueshieldOfficerPrimary
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#     - !type:CharacterAgeRequirement
+#       min: 21
+#   items:
+#     - WeaponLeverChester
+#     - BlueshieldAmmunitionBoxFilled
+#
+# - type: loadout
+#   id: LoadoutBSORifleBRDIR25
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 9 # Significant upgrade over a Chester, offered here for the STYLE. Intentionally priced at you not being able to buy all 3 medical items alongside it, plus being unable to buy it alongside the CQC Manual.
+#   canBeHeirloom: true
+#   guideEntry: SecurityWeapons
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBlueshieldOfficerPrimary
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#     - !type:CharacterAgeRequirement
+#       min: 21
+#   items:
+#     - WeaponSubMachineGunBRDIR25BSO # The Den sprites
+#
+# - type: loadout
+#   id: LoadoutBSOGreatShield
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 0
+#   canBeHeirloom: true
+#   guideEntry: SecurityWeapons
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBlueshieldOfficerPrimary
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#     - !type:CharacterAgeRequirement
+#       min: 21
+#   items:
+#     - BlueShieldShieldFilled
+#
+# - type: loadout
+#   id: LoadoutBSOMedkitCombatFilled
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 2
+#   requirements:
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - MedkitCombatFilled
+#
+# - type: loadout
+#   id: LoadoutBSOPortafib
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 2
+#   requirements:
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - Portafib
+#
+# - type: loadout
+#   id: LoadoutBSOCrewMonitor
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 2 # BSO's main job is to keep command safe, they should be able to monitor their status & location without that costing too many points.
+#   requirements:
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - HandheldCrewMonitor
+#
+# - type: loadout
+#   id: LoadoutBSOCQCManual
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 8 # You can run this alongside the 3 medical items, but then you will be restricted to free gear for everything else such as weapons or other utilities.
+#   requirements: # Knowledge does not occupy a weapon slot. You are a trained bodyguard, so it makes sense to have it. Balanced out by costing over half of your loadout points.
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - BSOManual
+#
+# - type: loadout
+#   id: LoadoutBSOTerminus
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 0
+#   canBeHeirloom: true
+#   guideEntry: SecurityWeapons
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBlueshieldOfficerPrimary
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#     - !type:CharacterAgeRequirement
+#       min: 21
+#     - !type:CharacterSpeciesRequirement
+#       species:
+#       - Oni
+#   items:
+#     - Terminus
+#
+# # Eyes
+#
+# # Gloves
+#
+# # Head
+# - type: loadout
+#   id: LoadoutClothingBlueshieldBeretNavy
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBlueshieldOfficerHats
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - ClothingHeadHatBeretNavy
+#
+# - type: loadout
+#   id: LoadoutClothingBlueshieldBeretOfficer
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBlueshieldOfficerHats
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - ClothingHeadHatBeretOfficer
+#
+# - type: loadout
+#   id: LoadoutClothingBlueshieldCowboyHat
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBlueshieldOfficerHats
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - ClothingHeadHatCowboyBlueshield
+#
+# # Id
+#
+# # Neck
+#
+# # Mask
+#
+# # Outer
+# - type: loadout
+#   id: LoadoutClothingBlueshieldArmoredJacket
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBlueshieldOfficerVests
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - ClothingBlueshieldArmoredJacket
+#
+# - type: loadout
+#   id: LoadoutClothingBlueshieldArmoredCowboyJacket
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBlueshieldOfficerVests
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - ClothingBlueshieldArmoredCowboyJacket
+#
+# - type: loadout
+#   id: LoadoutClothingBlueshieldArmorVest
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBlueshieldOfficerVests
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - ClothingBlueshieldArmourVest
+#
+# - type: loadout
+#   id: LoadoutClothingBlueshieldArmoredMarine
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBlueshieldOfficerVests
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - ClothingBlueshieldArmoredMarine
+#
+# - type: loadout
+#   id: LoadoutClothingBlueshieldArmoredVest
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBlueshieldOfficerVests
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - ClothingBlueshieldArmoredVest
+#
+# - type: loadout
+#   id: LoadoutClothingBlueshieldArmoredKimono
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBlueshieldOfficerVests
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - ClothingBlueshieldArmoredKimono
+#
+# - type: loadout
+#   id: LoadoutClothingBlueshieldArmoredCoat
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBlueshieldOfficerVests
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - ClothingBlueshieldArmoredCoat
+#
+# # Shoes
+#
+# # Uniforms
+# - type: loadout
+#   id: LoadoutClothingUniformJumpskirtBlueshieldOfficer
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBlueshieldOfficerUniforms
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - ClothingUniformJumpskirtBlueshieldOfficer
+#
+# - type: loadout
+#   id: LoadoutClothingUniformJumpsuitBlueshieldOfficer
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBlueshieldOfficerUniforms
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - ClothingUniformJumpsuitBlueshieldOfficer
+#
+# WWDP EDIT END

--- a/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
@@ -85,18 +85,20 @@
         - Captain
 
 # Belt
-- type: loadout
-  id: LoadoutCaptainSwordSheath
-  category: JobsCommandCaptain
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutCaptainBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - Captain
-  items:
-    - ClothingBeltSheathFilled
+
+# WWDP moved to locker
+# - type: loadout
+#   id: LoadoutCaptainSwordSheath
+#   category: JobsCommandCaptain
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutCaptainBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Captain
+#   items:
+#     - ClothingBeltSheathFilled
 
 # Ears
 
@@ -399,18 +401,19 @@
   items:
     - ClothingMaskGasCaptain
 
-- type: loadout
-  id: LoadoutCommandCapMaskGasCombat
-  category: JobsCommandCaptain
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutCaptainMask
-    - !type:CharacterJobRequirement
-      jobs:
-        - Captain
-  items:
-    - ClothingMaskGasCaptainCombat
+# WWDP disabled
+# - type: loadout
+#   id: LoadoutCommandCapMaskGasCombat
+#   category: JobsCommandCaptain
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutCaptainMask
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Captain
+#   items:
+#     - ClothingMaskGasCaptainCombat
 
 # Outer
 - type: loadout
@@ -426,46 +429,48 @@
   items:
     - ClothingOuterWinterCap
 
-- type: loadout
-  id: LoadoutCaptainOuterCarapace
-  category: JobsCommandCaptain
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutCaptainOuter
-    - !type:CharacterJobRequirement
-      jobs:
-        - Captain
-  items:
-    - ClothingOuterArmorCaptainCarapace
-
-- type: loadout
-  id: LoadoutCaptainOuterDogi
-  category: JobsCommandCaptain
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutCaptainOuter
-    - !type:CharacterJobRequirement
-      jobs:
-        - Captain
-  items:
-    - ClothingOuterArmorCaptainDogi
-
-- type: loadout
-  id: LoadoutCaptainOuterTrench
-  category: JobsCommandCaptain
-  cost: 0
-  exclusive: true
-  canBeHeirloom: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutCaptainOuter
-    - !type:CharacterJobRequirement
-      jobs:
-        - Captain
-  items:
-    - ClothingOuterCoatCapTrench
+# WWDP EDIT START, disabled
+# - type: loadout
+#   id: LoadoutCaptainOuterCarapace
+#   category: JobsCommandCaptain
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutCaptainOuter
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Captain
+#   items:
+#     - ClothingOuterArmorCaptainCarapace
+#
+# - type: loadout
+#   id: LoadoutCaptainOuterDogi
+#   category: JobsCommandCaptain
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutCaptainOuter
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Captain
+#   items:
+#     - ClothingOuterArmorCaptainDogi
+#
+# - type: loadout
+#   id: LoadoutCaptainOuterTrench
+#   category: JobsCommandCaptain
+#   cost: 0
+#   exclusive: true
+#   canBeHeirloom: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutCaptainOuter
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Captain
+#   items:
+#     - ClothingOuterCoatCapTrench
+# WWDP EDIT END
 
 # Shoes
 - type: loadout
@@ -510,19 +515,20 @@
   items:
     - ClothingShoesBootsWinterCap
 
-- type: loadout
-  id: LoadoutCaptainShoesCombat
-  category: JobsCommandCaptain
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutCaptainShoes
-    - !type:CharacterJobRequirement
-      jobs:
-        - Captain
-  items:
-    - ClothingShoesBootsCombatFilled
+# WWDP disabled
+# - type: loadout
+#   id: LoadoutCaptainShoesCombat
+#   category: JobsCommandCaptain
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutCaptainShoes
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Captain
+#   items:
+#     - ClothingShoesBootsCombatFilled
 
 # Uniforms
 - type: loadout
@@ -580,3 +586,18 @@
         - Captain
   items:
     - ClothingUniformJumpskirtCapFormalDress
+
+# WWDP added
+- type: loadout
+  id: LoadoutCommandCapJumpsuitCommand
+  category: JobsCommandCaptain
+  cost: 0
+  exclusive: true
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutCaptainUniforms
+  - !type:CharacterJobRequirement
+    jobs:
+    - Captain
+  items:
+  - ClothingUniformJumpsuitCommandCaptain

--- a/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
@@ -586,18 +586,3 @@
         - Captain
   items:
     - ClothingUniformJumpskirtCapFormalDress
-
-# WWDP added
-- type: loadout
-  id: LoadoutCommandCapJumpsuitCommand
-  category: JobsCommandCaptain
-  cost: 0
-  exclusive: true
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutCaptainUniforms
-  - !type:CharacterJobRequirement
-    jobs:
-    - Captain
-  items:
-  - ClothingUniformJumpsuitCommandCaptain

--- a/Resources/Prototypes/Loadouts/Jobs/Command/headOfPersonnel.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/headOfPersonnel.yml
@@ -272,33 +272,35 @@
   items:
     - ClothingOuterWinterHoP
 
-- type: loadout
-  id: LoadoutHeadOfPersonnelOuterArmoredCoat
-  category: JobsCommandHeadOfPersonnel
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutHeadOfPersonnelOuter
-    - !type:CharacterJobRequirement
-      jobs:
-        - HeadOfPersonnel
-  items:
-    - ClothingOuterCoatHoPArmored
-
-- type: loadout
-  id: LoadoutHeadOfPersonnelOuterDuraVest
-  category: JobsCommandHeadOfPersonnel
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutHeadOfPersonnelOuter
-    - !type:CharacterJobRequirement
-      jobs:
-        - HeadOfPersonnel
-  items:
-    - ClothingOuterArmorDuraVest
+# WWDP EDIT START - disabled
+# - type: loadout
+#   id: LoadoutHeadOfPersonnelOuterArmoredCoat
+#   category: JobsCommandHeadOfPersonnel
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutHeadOfPersonnelOuter
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - HeadOfPersonnel
+#   items:
+#     - ClothingOuterCoatHoPArmored
+#
+# - type: loadout
+#   id: LoadoutHeadOfPersonnelOuterDuraVest
+#   category: JobsCommandHeadOfPersonnel
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutHeadOfPersonnelOuter
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - HeadOfPersonnel
+#   items:
+#     - ClothingOuterArmorDuraVest
+# WWDP EDIT END
 
 # Shoes
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Command/headOfPersonnel.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/headOfPersonnel.yml
@@ -313,7 +313,7 @@
       group: LoadoutHeadOfPersonnelShoes
     - !type:CharacterJobRequirement
       jobs:
-        - Captain
+        - HeadOfPersonnel # WWDP
   items:
     - ClothingShoesBootsLaceup
 
@@ -327,7 +327,7 @@
       group: LoadoutHeadOfPersonnelShoes
     - !type:CharacterJobRequirement
       jobs:
-        - Captain
+        - HeadOfPersonnel # WWDP
   items:
     - ClothingShoesLeather
 

--- a/Resources/Prototypes/Loadouts/Jobs/Command/magistrate.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/magistrate.yml
@@ -1,141 +1,145 @@
-# Uncategorized
-# Backpacks
-
-# Belt
-
-# Ears
-
-# Equipment
-
-# Eyes
-
-# Gloves
-
-# Head
-- type: loadout
-  id: LoadoutClothingHeadChiefJustice
-  category: JobsCommandMagistrate
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMagistrateHead
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefJustice
-        - Magistrate
-  items:
-    - ClothingHeadHatCJToque
-
-# Id
-
-# Neck
-- type: loadout
-  id: LoadoutClothingNeckChiefJustice
-  category: JobsCommandMagistrate
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMagistrateNeck
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefJustice
-        - Magistrate
-  items:
-    - ClothingNeckCloakCJ
-
-# Mask
-
-# Outer
-- type: loadout
-  id: LoadoutClothingOuterChiefJustice
-  category: JobsCommandMagistrate
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMagistrateOuter
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefJustice
-        - Magistrate
-  items:
-    - ClothingOuterChiefJustice
-
-# Shoes
-
-# Uniforms
-- type: loadout
-  id: LoadoutClothingUniformJumpskirtMagistrate
-  category: JobsCommandMagistrate
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMagistrateUniforms
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefJustice
-        - Magistrate
-  items:
-    - ClothingUniformJumpskirtChiefJustice
-
-- type: loadout
-  id: LoadoutClothingUniformJumpsuitMagistrate
-  category: JobsCommandMagistrate
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMagistrateUniforms
-    - !type:CharacterJobRequirement
-      jobs:
-        - Magistrate
-  items:
-    - ClothingUniformJumpsuitMagistrate
-
-- type: loadout
-  id: LoadoutClothingUniformJumpsuitChiefJustice
-  category: JobsCommandMagistrate
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMagistrateUniforms
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefJustice
-        - Magistrate
-  items:
-    - ClothingUniformJumpsuitChiefJustice
-
-- type: loadout
-  id: LoadoutClothingUniformJumpsuitChiefJusticeFormal
-  category: JobsCommandMagistrate
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMagistrateUniforms
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefJustice
-        - Magistrate
-  items:
-    - ClothingUniformJumpsuitChiefJusticeFormal
-
-- type: loadout
-  id: LoadoutClothingUniformJumpsuitChiefJusticeWhite
-  category: JobsCommandMagistrate
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMagistrateUniforms
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefJustice
-        - Magistrate
-  items:
-    - ClothingUniformJumpsuitChiefJusticeWhite
+# WWDP EDIT START -  role removed
+#
+# # Uncategorized
+# # Backpacks
+#
+# # Belt
+#
+# # Ears
+#
+# # Equipment
+#
+# # Eyes
+#
+# # Gloves
+#
+# # Head
+# - type: loadout
+#   id: LoadoutClothingHeadChiefJustice
+#   category: JobsCommandMagistrate
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMagistrateHead
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefJustice
+#         - Magistrate
+#   items:
+#     - ClothingHeadHatCJToque
+#
+# # Id
+#
+# # Neck
+# - type: loadout
+#   id: LoadoutClothingNeckChiefJustice
+#   category: JobsCommandMagistrate
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMagistrateNeck
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefJustice
+#         - Magistrate
+#   items:
+#     - ClothingNeckCloakCJ
+#
+# # Mask
+#
+# # Outer
+# - type: loadout
+#   id: LoadoutClothingOuterChiefJustice
+#   category: JobsCommandMagistrate
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMagistrateOuter
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefJustice
+#         - Magistrate
+#   items:
+#     - ClothingOuterChiefJustice
+#
+# # Shoes
+#
+# # Uniforms
+# - type: loadout
+#   id: LoadoutClothingUniformJumpskirtMagistrate
+#   category: JobsCommandMagistrate
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMagistrateUniforms
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefJustice
+#         - Magistrate
+#   items:
+#     - ClothingUniformJumpskirtChiefJustice
+#
+# - type: loadout
+#   id: LoadoutClothingUniformJumpsuitMagistrate
+#   category: JobsCommandMagistrate
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMagistrateUniforms
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Magistrate
+#   items:
+#     - ClothingUniformJumpsuitMagistrate
+#
+# - type: loadout
+#   id: LoadoutClothingUniformJumpsuitChiefJustice
+#   category: JobsCommandMagistrate
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMagistrateUniforms
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefJustice
+#         - Magistrate
+#   items:
+#     - ClothingUniformJumpsuitChiefJustice
+#
+# - type: loadout
+#   id: LoadoutClothingUniformJumpsuitChiefJusticeFormal
+#   category: JobsCommandMagistrate
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMagistrateUniforms
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefJustice
+#         - Magistrate
+#   items:
+#     - ClothingUniformJumpsuitChiefJusticeFormal
+#
+# - type: loadout
+#   id: LoadoutClothingUniformJumpsuitChiefJusticeWhite
+#   category: JobsCommandMagistrate
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMagistrateUniforms
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefJustice
+#         - Magistrate
+#   items:
+#     - ClothingUniformJumpsuitChiefJusticeWhite
+#
+# WWDP EDIT END

--- a/Resources/Prototypes/Loadouts/Jobs/Command/nanorep.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/nanorep.yml
@@ -1,238 +1,242 @@
-# Uncategorized
-# Backpacks
-- type: loadout
-  id: LoadoutClothingBackpackSatchelNanorep
-  category: JobsCommandNanorep
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutNanorepBackpacks
-    - !type:CharacterJobRequirement
-      jobs:
-        - NanotrasenRepresentative
-  items:
-    - ClothingBackpackSatchelNanorep
-
-# Belt
-
-# Ears
-
-# Equipment
-- type: loadout
-  id: LoadoutNanotrasenRepresentativeDisabler
-  category: JobsCommandNanorep
-  cost: 0
-  canBeHeirloom: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutNanotrasenRepresentativeWeapon
-    - !type:CharacterJobRequirement
-      jobs:
-        - NanotrasenRepresentative
-  items:
-    - WeaponCCDisabler
-
-- type: loadout
-  id: LoadoutCorporateLiaisonStamp
-  category: JobsCommandNanorep
-  cost: 0
-  canBeHeirloom: true
-  requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - NanotrasenRepresentative
-  items:
-    - RubberStampCorporateLiaison
-# Eyes
-
-# Gloves
-
-# Head
-- type: loadout
-  id: LoadoutHeadBeretWhiteCorporateLiaison
-  category: JobsCommandNanorep
-  cost: 0
-  exclusive: true
-  customColorTint: true
-  items:
-    - ClothingHeadHatBeretWhite
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutHead
-    - !type:CharacterJobRequirement
-      jobs:
-        - NanotrasenRepresentative
-# Id
-
-# Neck
-
-# Mask
-
-# Outer
-- type: loadout
-  id: LoadoutClothingOuterCorporateJacketNanoTrasenCorporateLiaison
-  category: JobsCommandNanorep
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutNanorepUniforms
-    - !type:CharacterJobRequirement
-      jobs:
-        - NanotrasenRepresentative
-    - !type:CharacterEmployerRequirement
-      employers:
-      - NanoTrasen
-  items:
-    - ClothingOuterCorporateJacket
-
-- type: loadout
-  id: LoadoutClothingOuterCorporateJacketZavodskoiInterstellarCorporateLiaison
-  category: JobsCommandNanorep
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutNanorepUniforms
-    - !type:CharacterJobRequirement
-      jobs:
-        - NanotrasenRepresentative
-    - !type:CharacterEmployerRequirement
-      employers:
-      - ZavodskoiInterstellar
-  items:
-    - ClothingOuterZiCorporateJacket
-
-- type: loadout
-  id: LoadoutClothingOuterCorporateJacketEinsteinEnginesCorporateLiaison
-  category: JobsCommandNanorep
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutNanorepUniforms
-    - !type:CharacterJobRequirement
-      jobs:
-        - NanotrasenRepresentative
-    - !type:CharacterEmployerRequirement
-      employers:
-      - EinsteinEngines
-  items:
-    - ClothingOuterEeCorporateJacket
-
-- type: loadout
-  id: LoadoutClothingOuterCorporateJacketHephaestusIndustriesCorporateLiaison
-  category: JobsCommandNanorep
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutNanorepUniforms
-    - !type:CharacterJobRequirement
-      jobs:
-        - NanotrasenRepresentative
-    - !type:CharacterEmployerRequirement
-      employers:
-      - HephaestusIndustries
-  items:
-    - ClothingOuterHiCorporateJacket
-
-- type: loadout
-  id: LoadoutClothingOuterCorporateJacketInterdyneCorporateLiaison
-  category: JobsCommandNanorep
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutNanorepUniforms
-    - !type:CharacterJobRequirement
-      jobs:
-        - NanotrasenRepresentative
-    - !type:CharacterEmployerRequirement
-      employers:
-      - Interdyne
-  items:
-    - ClothingOuterIdCorporateJacket
-
-- type: loadout
-  id: LoadoutClothingOuterCorporateJacketZengHuPharmaceuticalsCorporateLiaison
-  category: JobsCommandNanorep
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutNanorepUniforms
-    - !type:CharacterJobRequirement
-      jobs:
-        - NanotrasenRepresentative
-    - !type:CharacterEmployerRequirement
-      employers:
-      - ZengHuPharmaceuticals
-  items:
-    - ClothingOuterZhCorporateJacket
-
-- type: loadout
-  id: LoadoutClothingOuterCorporateJacketIdrisIncorporatedCorporateLiaison
-  category: JobsCommandNanorep
-  cost: 0
-  guideEntry: IdrisIncorporated
-  items:
-    - ClothingOuterIiCorporateJacket
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutNanorepUniforms
-    - !type:CharacterJobRequirement
-      jobs:
-        - NanotrasenRepresentative
-    - !type:CharacterEmployerRequirement
-        employers:
-        - IdrisIncorporated
-
-- type: loadout
-  id: LoadoutClothingOuterCorporateJacketOrionExpressCorporateLiaison
-  category: JobsCommandNanorep
-  cost: 0
-  guideEntry: OrionExpress
-  items:
-    - ClothingOuterOeCorporateJacket
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutNanorepUniforms
-    - !type:CharacterJobRequirement
-      jobs:
-        - NanotrasenRepresentative
-    - !type:CharacterEmployerRequirement
-        employers:
-        - OrionExpress
-
-# Shoes
-
-# Uniforms
-- type: loadout
-  id: LoadoutClothingUniformJumpskirtNanotrasenRepresentative
-  category: JobsCommandNanorep
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutNanorepUniforms
-    - !type:CharacterJobRequirement
-      jobs:
-        - NanotrasenRepresentative
-  items:
-    - ClothingUniformJumpskirtNanotrasenRepresentative
-
-- type: loadout
-  id: LoadoutClothingUniformJumpsuitNanotrasenRepresentative
-  category: JobsCommandNanorep
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutNanorepUniforms
-    - !type:CharacterJobRequirement
-      jobs:
-        - NanotrasenRepresentative
-  items:
-    - ClothingUniformJumpsuitNanotrasenRepresentative
+# WWDP EDIT START -  role removed
+#
+# # Uncategorized
+# # Backpacks
+# - type: loadout
+#   id: LoadoutClothingBackpackSatchelNanorep
+#   category: JobsCommandNanorep
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutNanorepBackpacks
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - NanotrasenRepresentative
+#   items:
+#     - ClothingBackpackSatchelNanorep
+#
+# # Belt
+#
+# # Ears
+#
+# # Equipment
+# - type: loadout
+#   id: LoadoutNanotrasenRepresentativeDisabler
+#   category: JobsCommandNanorep
+#   cost: 0
+#   canBeHeirloom: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutNanotrasenRepresentativeWeapon
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - NanotrasenRepresentative
+#   items:
+#     - WeaponCCDisabler
+#
+# - type: loadout
+#   id: LoadoutCorporateLiaisonStamp
+#   category: JobsCommandNanorep
+#   cost: 0
+#   canBeHeirloom: true
+#   requirements:
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - NanotrasenRepresentative
+#   items:
+#     - RubberStampCorporateLiaison
+# # Eyes
+#
+# # Gloves
+#
+# # Head
+# - type: loadout
+#   id: LoadoutHeadBeretWhiteCorporateLiaison
+#   category: JobsCommandNanorep
+#   cost: 0
+#   exclusive: true
+#   customColorTint: true
+#   items:
+#     - ClothingHeadHatBeretWhite
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutHead
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - NanotrasenRepresentative
+# # Id
+#
+# # Neck
+#
+# # Mask
+#
+# # Outer
+# - type: loadout
+#   id: LoadoutClothingOuterCorporateJacketNanoTrasenCorporateLiaison
+#   category: JobsCommandNanorep
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutNanorepUniforms
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - NanotrasenRepresentative
+#     - !type:CharacterEmployerRequirement
+#       employers:
+#       - NanoTrasen
+#   items:
+#     - ClothingOuterCorporateJacket
+#
+# - type: loadout
+#   id: LoadoutClothingOuterCorporateJacketZavodskoiInterstellarCorporateLiaison
+#   category: JobsCommandNanorep
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutNanorepUniforms
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - NanotrasenRepresentative
+#     - !type:CharacterEmployerRequirement
+#       employers:
+#       - ZavodskoiInterstellar
+#   items:
+#     - ClothingOuterZiCorporateJacket
+#
+# - type: loadout
+#   id: LoadoutClothingOuterCorporateJacketEinsteinEnginesCorporateLiaison
+#   category: JobsCommandNanorep
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutNanorepUniforms
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - NanotrasenRepresentative
+#     - !type:CharacterEmployerRequirement
+#       employers:
+#       - EinsteinEngines
+#   items:
+#     - ClothingOuterEeCorporateJacket
+#
+# - type: loadout
+#   id: LoadoutClothingOuterCorporateJacketHephaestusIndustriesCorporateLiaison
+#   category: JobsCommandNanorep
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutNanorepUniforms
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - NanotrasenRepresentative
+#     - !type:CharacterEmployerRequirement
+#       employers:
+#       - HephaestusIndustries
+#   items:
+#     - ClothingOuterHiCorporateJacket
+#
+# - type: loadout
+#   id: LoadoutClothingOuterCorporateJacketInterdyneCorporateLiaison
+#   category: JobsCommandNanorep
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutNanorepUniforms
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - NanotrasenRepresentative
+#     - !type:CharacterEmployerRequirement
+#       employers:
+#       - Interdyne
+#   items:
+#     - ClothingOuterIdCorporateJacket
+#
+# - type: loadout
+#   id: LoadoutClothingOuterCorporateJacketZengHuPharmaceuticalsCorporateLiaison
+#   category: JobsCommandNanorep
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutNanorepUniforms
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - NanotrasenRepresentative
+#     - !type:CharacterEmployerRequirement
+#       employers:
+#       - ZengHuPharmaceuticals
+#   items:
+#     - ClothingOuterZhCorporateJacket
+#
+# - type: loadout
+#   id: LoadoutClothingOuterCorporateJacketIdrisIncorporatedCorporateLiaison
+#   category: JobsCommandNanorep
+#   cost: 0
+#   guideEntry: IdrisIncorporated
+#   items:
+#     - ClothingOuterIiCorporateJacket
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutNanorepUniforms
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - NanotrasenRepresentative
+#     - !type:CharacterEmployerRequirement
+#         employers:
+#         - IdrisIncorporated
+#
+# - type: loadout
+#   id: LoadoutClothingOuterCorporateJacketOrionExpressCorporateLiaison
+#   category: JobsCommandNanorep
+#   cost: 0
+#   guideEntry: OrionExpress
+#   items:
+#     - ClothingOuterOeCorporateJacket
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutNanorepUniforms
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - NanotrasenRepresentative
+#     - !type:CharacterEmployerRequirement
+#         employers:
+#         - OrionExpress
+#
+# # Shoes
+#
+# # Uniforms
+# - type: loadout
+#   id: LoadoutClothingUniformJumpskirtNanotrasenRepresentative
+#   category: JobsCommandNanorep
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutNanorepUniforms
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - NanotrasenRepresentative
+#   items:
+#     - ClothingUniformJumpskirtNanotrasenRepresentative
+#
+# - type: loadout
+#   id: LoadoutClothingUniformJumpsuitNanotrasenRepresentative
+#   category: JobsCommandNanorep
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutNanorepUniforms
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - NanotrasenRepresentative
+#   items:
+#     - ClothingUniformJumpsuitNanotrasenRepresentative
+#
+# WWDP EDIT END

--- a/Resources/Prototypes/Loadouts/Jobs/Command/uncategorized.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/uncategorized.yml
@@ -6,34 +6,37 @@
 # Ears
 
 # Equipment
-- type: loadout
-  id: LoadoutCommandTelescopicBaton
-  category: JobsCommandAUncategorized
-  cost: 3
-  exclusive: true
-  canBeHeirloom: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutCommandSelfDefense
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Command
-  items:
-  - TelescopicBaton
 
-- type: loadout
-  id: LoadoutCommandDisabler
-  category: JobsCommandAUncategorized
-  cost: 2
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutCommandSelfDefense
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Command
-  items:
-  - WeaponDisabler
+# WWDP disabled, moved to starting kits
+# - type: loadout
+#   id: LoadoutCommandTelescopicBaton
+#   category: JobsCommandAUncategorized
+#   cost: 3
+#   exclusive: true
+#   canBeHeirloom: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutCommandSelfDefense
+#     - !type:CharacterDepartmentRequirement
+#       departments:
+#       - Command
+#   items:
+#   - TelescopicBaton
+
+# WWDP disabled
+# - type: loadout
+#   id: LoadoutCommandDisabler
+#   category: JobsCommandAUncategorized
+#   cost: 2
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutCommandSelfDefense
+#     - !type:CharacterDepartmentRequirement
+#       departments:
+#       - Command
+#   items:
+#   - WeaponDisabler
 
 # WWDP removed (cringe)
 # - type: loadout
@@ -50,19 +53,20 @@
 #   items:
 #   - Stunbaton
 
-- type: loadout
-  id: LoadoutCommandFlash
-  category: JobsCommandAUncategorized
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutCommandSelfDefense
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Command
-  items:
-  - Flash
+# WWDP disabled
+# - type: loadout
+#   id: LoadoutCommandFlash
+#   category: JobsCommandAUncategorized
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutCommandSelfDefense
+#     - !type:CharacterDepartmentRequirement
+#       departments:
+#       - Command
+#   items:
+#   - Flash
 
 # Eyes
 

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/atmosphericTechnician.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/atmosphericTechnician.yml
@@ -43,219 +43,225 @@
     - ClothingBackpackDuffelAtmospherics
 
 # Belt
-- type: loadout
-  id: LoadoutAtmosphericTechnicianBeltUtility
-  category: JobsEngineeringAtmosphericTechnician
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAtmosphericTechnicianBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - AtmosphericTechnician
-  items:
-    - ClothingBeltUtility
 
-- type: loadout
-  id: LoadoutAtmosphericTechnicianBeltUtilityAtmos
-  category: JobsEngineeringAtmosphericTechnician
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAtmosphericTechnicianBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - AtmosphericTechnician
-  items:
-    - ClothingBeltUtilityAtmos
+# WWDP edit start - no starter loot
+# - type: loadout
+#   id: LoadoutAtmosphericTechnicianBeltUtility
+#   category: JobsEngineeringAtmosphericTechnician
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAtmosphericTechnicianBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - AtmosphericTechnician
+#   items:
+#     - ClothingBeltUtility
+#
+# - type: loadout
+#   id: LoadoutAtmosphericTechnicianBeltUtilityAtmos
+#   category: JobsEngineeringAtmosphericTechnician
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAtmosphericTechnicianBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - AtmosphericTechnician
+#   items:
+#     - ClothingBeltUtilityAtmos
+# WWDP EDIT END
 
 # Ears
 
 # Equipment
-- type: loadout
-  id: LoadoutAtmosphericTechnicianEquipmentBoxInflatable
-  category: JobsEngineeringAtmosphericTechnician
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAtmosphericTechnicianEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - AtmosphericTechnician
-  items:
-    - BoxInflatable
 
-- type: loadout
-  id: LoadoutAtmosphericTechnicianEquipmentMedkitOxygen
-  category: JobsEngineeringAtmosphericTechnician
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAtmosphericTechnicianEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - AtmosphericTechnician
-  items:
-    - MedkitOxygenFilled
-
-- type: loadout
-  id: LoadoutAtmosphericTechnicianEquipmentRCD
-  category: JobsEngineeringAtmosphericTechnician
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAtmosphericTechnicianEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - AtmosphericTechnician
-  items:
-    - RCD
-    - RCDAmmo
-
-- type: loadout
-  id: LoadoutAtmosphericTechnicianEquipmentPowerDrill
-  category: JobsEngineeringAtmosphericTechnician
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAtmosphericTechnicianEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - AtmosphericTechnician
-  items:
-    - PowerDrill
-
-- type: loadout
-  id: LoadoutAtmosphericTechnicianEquipmentSheetSteel
-  category: JobsEngineeringAtmosphericTechnician
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAtmosphericTechnicianEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - AtmosphericTechnician
-  items:
-    - SheetSteel
-
-- type: loadout
-  id: LoadoutAtmosphericTechnicianEquipmentSheetSteel10
-  category: JobsEngineeringAtmosphericTechnician
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAtmosphericTechnicianEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - AtmosphericTechnician
-  items:
-    - SheetSteel10
-
-- type: loadout
-  id: LoadoutAtmosphericTechnicianEquipmentSheetPlasteel
-  category: JobsEngineeringAtmosphericTechnician
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAtmosphericTechnicianEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - AtmosphericTechnician
-  items:
-    - SheetPlasteel
-
-- type: loadout
-  id: LoadoutAtmosphericTechnicianEquipmentSheetPlasteel10
-  category: JobsEngineeringAtmosphericTechnician
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAtmosphericTechnicianEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - AtmosphericTechnician
-  items:
-    - SheetPlasteel10
-
-- type: loadout
-  id: LoadoutAtmosphericTechnicianEquipmentSheetGlass
-  category: JobsEngineeringAtmosphericTechnician
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAtmosphericTechnicianEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - AtmosphericTechnician
-  items:
-    - SheetGlass
-
-- type: loadout
-  id: LoadoutAtmosphericTechnicianEquipmentSheetGlass10
-  category: JobsEngineeringAtmosphericTechnician
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAtmosphericTechnicianEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - AtmosphericTechnician
-  items:
-    - SheetGlass10
-
-- type: loadout
-  id: LoadoutAtmosphericTechnicianEquipmentMaterialWoodPlank
-  category: JobsEngineeringAtmosphericTechnician
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAtmosphericTechnicianEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - AtmosphericTechnician
-  items:
-    - MaterialWoodPlank
-
-- type: loadout
-  id: LoadoutAtmosphericTechnicianEquipmentMaterialWoodPlank10
-  category: JobsEngineeringAtmosphericTechnician
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAtmosphericTechnicianEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - AtmosphericTechnician
-  items:
-    - MaterialWoodPlank10
-
-- type: loadout
-  id: LoadoutAtmosphericTechnicianEquipmentSheetPlastic
-  category: JobsEngineeringAtmosphericTechnician
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAtmosphericTechnicianEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - AtmosphericTechnician
-  items:
-    - SheetPlastic
-
-- type: loadout
-  id: LoadoutAtmosphericTechnicianEquipmentSheetPlastic10
-  category: JobsEngineeringAtmosphericTechnician
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutAtmosphericTechnicianEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - AtmosphericTechnician
-  items:
-    - SheetPlastic10
+# WWDP edit start - no starter loot
+# - type: loadout
+#   id: LoadoutAtmosphericTechnicianEquipmentBoxInflatable
+#   category: JobsEngineeringAtmosphericTechnician
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAtmosphericTechnicianEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - AtmosphericTechnician
+#   items:
+#     - BoxInflatable
+#
+# - type: loadout
+#   id: LoadoutAtmosphericTechnicianEquipmentMedkitOxygen
+#   category: JobsEngineeringAtmosphericTechnician
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAtmosphericTechnicianEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - AtmosphericTechnician
+#   items:
+#     - MedkitOxygenFilled
+#
+# - type: loadout
+#   id: LoadoutAtmosphericTechnicianEquipmentRCD
+#   category: JobsEngineeringAtmosphericTechnician
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAtmosphericTechnicianEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - AtmosphericTechnician
+#   items:
+#     - RCD
+#     - RCDAmmo
+#
+# - type: loadout
+#   id: LoadoutAtmosphericTechnicianEquipmentPowerDrill
+#   category: JobsEngineeringAtmosphericTechnician
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAtmosphericTechnicianEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - AtmosphericTechnician
+#   items:
+#     - PowerDrill
+#
+# - type: loadout
+#   id: LoadoutAtmosphericTechnicianEquipmentSheetSteel
+#   category: JobsEngineeringAtmosphericTechnician
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAtmosphericTechnicianEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - AtmosphericTechnician
+#   items:
+#     - SheetSteel
+#
+# - type: loadout
+#   id: LoadoutAtmosphericTechnicianEquipmentSheetSteel10
+#   category: JobsEngineeringAtmosphericTechnician
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAtmosphericTechnicianEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - AtmosphericTechnician
+#   items:
+#     - SheetSteel10
+#
+# - type: loadout
+#   id: LoadoutAtmosphericTechnicianEquipmentSheetPlasteel
+#   category: JobsEngineeringAtmosphericTechnician
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAtmosphericTechnicianEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - AtmosphericTechnician
+#   items:
+#     - SheetPlasteel
+#
+# - type: loadout
+#   id: LoadoutAtmosphericTechnicianEquipmentSheetPlasteel10
+#   category: JobsEngineeringAtmosphericTechnician
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAtmosphericTechnicianEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - AtmosphericTechnician
+#   items:
+#     - SheetPlasteel10
+#
+# - type: loadout
+#   id: LoadoutAtmosphericTechnicianEquipmentSheetGlass
+#   category: JobsEngineeringAtmosphericTechnician
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAtmosphericTechnicianEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - AtmosphericTechnician
+#   items:
+#     - SheetGlass
+#
+# - type: loadout
+#   id: LoadoutAtmosphericTechnicianEquipmentSheetGlass10
+#   category: JobsEngineeringAtmosphericTechnician
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAtmosphericTechnicianEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - AtmosphericTechnician
+#   items:
+#     - SheetGlass10
+#
+# - type: loadout
+#   id: LoadoutAtmosphericTechnicianEquipmentMaterialWoodPlank
+#   category: JobsEngineeringAtmosphericTechnician
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAtmosphericTechnicianEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - AtmosphericTechnician
+#   items:
+#     - MaterialWoodPlank
+#
+# - type: loadout
+#   id: LoadoutAtmosphericTechnicianEquipmentMaterialWoodPlank10
+#   category: JobsEngineeringAtmosphericTechnician
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAtmosphericTechnicianEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - AtmosphericTechnician
+#   items:
+#     - MaterialWoodPlank10
+#
+# - type: loadout
+#   id: LoadoutAtmosphericTechnicianEquipmentSheetPlastic
+#   category: JobsEngineeringAtmosphericTechnician
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAtmosphericTechnicianEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - AtmosphericTechnician
+#   items:
+#     - SheetPlastic
+#
+# - type: loadout
+#   id: LoadoutAtmosphericTechnicianEquipmentSheetPlastic10
+#   category: JobsEngineeringAtmosphericTechnician
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutAtmosphericTechnicianEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - AtmosphericTechnician
+#   items:
+#     - SheetPlastic10
+# WWDP edit end
 
 # Eyes
 

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/chiefEngineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/chiefEngineer.yml
@@ -43,376 +43,382 @@
     - ClothingBackpackDuffelChiefEngineerFilled
 
 # Belt
-- type: loadout
-  id: LoadoutChiefEngineerBelt
-  category: JobsEngineeringChiefEngineer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - ClothingBeltChiefEngineer
 
-- type: loadout
-  id: LoadoutChiefEngineerBeltFilled
-  category: JobsEngineeringChiefEngineer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - ClothingBeltChiefEngineerFilled
+# WWDP EDIT START - disabled
+# - type: loadout
+#   id: LoadoutChiefEngineerBelt
+#   category: JobsEngineeringChiefEngineer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - ClothingBeltChiefEngineer
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerBeltFilled
+#   category: JobsEngineeringChiefEngineer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - ClothingBeltChiefEngineerFilled
+# WWDP EDIT END
 
 # Ears
 
 # Equipment
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentBoxInflatable
-  category: JobsEngineeringChiefEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - BoxInflatable
 
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentMedkitOxygen
-  category: JobsEngineeringChiefEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - MedkitOxygenFilled
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentRCD
-  category: JobsEngineeringChiefEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - RCD
-    - RCDAmmo
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentRCDAmmoSpare
-  category: JobsEngineeringChiefEngineer
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - RCDAmmo
-    - RCDAmmo
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentSheetSteel
-  category: JobsEngineeringChiefEngineer
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - SheetSteel
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentSheetSteel10
-  category: JobsEngineeringChiefEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - SheetSteel10
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentSheetPlasteel
-  category: JobsEngineeringChiefEngineer
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - SheetPlasteel
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentSheetPlasteel10
-  category: JobsEngineeringChiefEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - SheetPlasteel10
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentSheetGlass
-  category: JobsEngineeringChiefEngineer
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - SheetGlass
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentSheetGlass10
-  category: JobsEngineeringChiefEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - SheetGlass10
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentMaterialWoodPlank
-  category: JobsEngineeringChiefEngineer
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - MaterialWoodPlank
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentMaterialWoodPlank10
-  category: JobsEngineeringChiefEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - MaterialWoodPlank10
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentSheetRGlass
-  category: JobsEngineeringChiefEngineer
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - SheetRGlass
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentSheetRGlass10
-  category: JobsEngineeringChiefEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - SheetRGlass10
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentSheetUGlass
-  category: JobsEngineeringChiefEngineer
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - SheetUGlass
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentSheetUGlass10
-  category: JobsEngineeringChiefEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - SheetUGlass10
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentSheetRUGlass
-  category: JobsEngineeringChiefEngineer
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - SheetRUGlass
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentSheetRUGlass10
-  category: JobsEngineeringChiefEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - SheetRUGlass10
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentSheetPGlass
-  category: JobsEngineeringChiefEngineer
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - SheetPGlass
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentSheetPGlass10
-  category: JobsEngineeringChiefEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - SheetPGlass10
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentSheetRPGlass
-  category: JobsEngineeringChiefEngineer
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - SheetRPGlass
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentSheetRPGlass10
-  category: JobsEngineeringChiefEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - SheetRPGlass10
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentSheetClockworkGlass
-  category: JobsEngineeringChiefEngineer
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - SheetClockworkGlass
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentSheetClockworkGlass10
-  category: JobsEngineeringChiefEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - SheetClockworkGlass10
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentSheetPlastic
-  category: JobsEngineeringChiefEngineer
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - SheetPlastic
-
-- type: loadout
-  id: LoadoutChiefEngineerEquipmentSheetPlastic10
-  category: JobsEngineeringChiefEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-  items:
-    - SheetPlastic10
+# WWDP edit start - starter loot disabled
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentBoxInflatable
+#   category: JobsEngineeringChiefEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - BoxInflatable
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentMedkitOxygen
+#   category: JobsEngineeringChiefEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - MedkitOxygenFilled
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentRCD
+#   category: JobsEngineeringChiefEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - RCD
+#     - RCDAmmo
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentRCDAmmoSpare
+#   category: JobsEngineeringChiefEngineer
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - RCDAmmo
+#     - RCDAmmo
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentSheetSteel
+#   category: JobsEngineeringChiefEngineer
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - SheetSteel
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentSheetSteel10
+#   category: JobsEngineeringChiefEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - SheetSteel10
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentSheetPlasteel
+#   category: JobsEngineeringChiefEngineer
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - SheetPlasteel
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentSheetPlasteel10
+#   category: JobsEngineeringChiefEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - SheetPlasteel10
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentSheetGlass
+#   category: JobsEngineeringChiefEngineer
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - SheetGlass
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentSheetGlass10
+#   category: JobsEngineeringChiefEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - SheetGlass10
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentMaterialWoodPlank
+#   category: JobsEngineeringChiefEngineer
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - MaterialWoodPlank
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentMaterialWoodPlank10
+#   category: JobsEngineeringChiefEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - MaterialWoodPlank10
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentSheetRGlass
+#   category: JobsEngineeringChiefEngineer
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - SheetRGlass
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentSheetRGlass10
+#   category: JobsEngineeringChiefEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - SheetRGlass10
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentSheetUGlass
+#   category: JobsEngineeringChiefEngineer
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - SheetUGlass
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentSheetUGlass10
+#   category: JobsEngineeringChiefEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - SheetUGlass10
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentSheetRUGlass
+#   category: JobsEngineeringChiefEngineer
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - SheetRUGlass
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentSheetRUGlass10
+#   category: JobsEngineeringChiefEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - SheetRUGlass10
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentSheetPGlass
+#   category: JobsEngineeringChiefEngineer
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - SheetPGlass
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentSheetPGlass10
+#   category: JobsEngineeringChiefEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - SheetPGlass10
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentSheetRPGlass
+#   category: JobsEngineeringChiefEngineer
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - SheetRPGlass
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentSheetRPGlass10
+#   category: JobsEngineeringChiefEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - SheetRPGlass10
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentSheetClockworkGlass
+#   category: JobsEngineeringChiefEngineer
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - SheetClockworkGlass
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentSheetClockworkGlass10
+#   category: JobsEngineeringChiefEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - SheetClockworkGlass10
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentSheetPlastic
+#   category: JobsEngineeringChiefEngineer
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - SheetPlastic
+#
+# - type: loadout
+#   id: LoadoutChiefEngineerEquipmentSheetPlastic10
+#   category: JobsEngineeringChiefEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefEngineer
+#   items:
+#     - SheetPlastic10
+# WWDP edit end
 
 # Eyes
 

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/seniorEngineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/seniorEngineer.yml
@@ -2,428 +2,432 @@
 # Backpacks
 
 # Belt
-- type: loadout
-  id: LoadoutSeniorEngineerBeltUtility
-  category: JobsEngineeringSeniorEngineer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - ClothingBeltUtility
 
-- type: loadout
-  id: LoadoutSeniorEngineerBeltUtilityEngineering
-  category: JobsEngineeringSeniorEngineer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - ClothingBeltUtilityEngineering
-
-- type: loadout
-  id: LoadoutSeniorEngineerBeltUtilityAtmos
-  category: JobsEngineeringSeniorEngineer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - ClothingBeltUtilityAtmos
+# WWDP edit start - no roundstart loot
+# - type: loadout
+#   id: LoadoutSeniorEngineerBeltUtility
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - ClothingBeltUtility
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerBeltUtilityEngineering
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - ClothingBeltUtilityEngineering
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerBeltUtilityAtmos
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - ClothingBeltUtilityAtmos
 
 # Ears
 
 # Equipment
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentBoxInflatable
-  category: JobsEngineeringSeniorEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - BoxInflatable
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentBoxInflatable
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - BoxInflatable
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentMedkitOxygen
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - MedkitOxygenFilled
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentRCD
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - RCD
+#     - RCDAmmo
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentRCDAmmo1
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - RCDAmmo
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentRCDAmmo2
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - RCDAmmo
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentPowerDrill
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - PowerDrill
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentSheetSteel
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - SheetSteel
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentSheetSteel10
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - SheetSteel10
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentSheetPlasteel
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - SheetPlasteel
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentSheetPlasteel10
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - SheetPlasteel10
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentSheetGlass
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - SheetGlass
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentSheetGlass10
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - SheetGlass10
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentMaterialWoodPlank
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - MaterialWoodPlank
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentMaterialWoodPlank10
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - MaterialWoodPlank10
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentSheetRGlass
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - SheetRGlass
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentSheetRGlass10
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - SheetRGlass10
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentSheetUGlass
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - SheetUGlass
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentSheetUGlass10
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - SheetUGlass10
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentSheetRUGlass
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - SheetRUGlass
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentSheetRUGlass10
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - SheetRUGlass10
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentSheetPGlass
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - SheetPGlass
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentSheetPGlass10
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - SheetPGlass10
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentSheetRPGlass
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - SheetRPGlass
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentSheetRPGlass10
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - SheetRPGlass10
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentSheetClockworkGlass
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - SheetClockworkGlass
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentSheetClockworkGlass10
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - SheetClockworkGlass10
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentSheetPlastic
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - SheetPlastic
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentSheetPlastic10
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - SheetPlastic10
+#
+# - type: loadout
+#   id: LoadoutSeniorEngineerEquipmentExperimentalWeldingTool
+#   category: JobsEngineeringSeniorEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorEngineerEquipmentExtra
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorEngineer
+#   items:
+#     - WelderExperimental
+# WWDP edit end
 
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentMedkitOxygen
-  category: JobsEngineeringSeniorEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - MedkitOxygenFilled
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentRCD
-  category: JobsEngineeringSeniorEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - RCD
-    - RCDAmmo
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentRCDAmmo1
-  category: JobsEngineeringSeniorEngineer
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - RCDAmmo
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentRCDAmmo2
-  category: JobsEngineeringSeniorEngineer
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - RCDAmmo
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentPowerDrill
-  category: JobsEngineeringSeniorEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - PowerDrill
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentSheetSteel
-  category: JobsEngineeringSeniorEngineer
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - SheetSteel
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentSheetSteel10
-  category: JobsEngineeringSeniorEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - SheetSteel10
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentSheetPlasteel
-  category: JobsEngineeringSeniorEngineer
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - SheetPlasteel
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentSheetPlasteel10
-  category: JobsEngineeringSeniorEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - SheetPlasteel10
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentSheetGlass
-  category: JobsEngineeringSeniorEngineer
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - SheetGlass
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentSheetGlass10
-  category: JobsEngineeringSeniorEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - SheetGlass10
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentMaterialWoodPlank
-  category: JobsEngineeringSeniorEngineer
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - MaterialWoodPlank
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentMaterialWoodPlank10
-  category: JobsEngineeringSeniorEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - MaterialWoodPlank10
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentSheetRGlass
-  category: JobsEngineeringSeniorEngineer
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - SheetRGlass
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentSheetRGlass10
-  category: JobsEngineeringSeniorEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - SheetRGlass10
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentSheetUGlass
-  category: JobsEngineeringSeniorEngineer
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - SheetUGlass
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentSheetUGlass10
-  category: JobsEngineeringSeniorEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - SheetUGlass10
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentSheetRUGlass
-  category: JobsEngineeringSeniorEngineer
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - SheetRUGlass
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentSheetRUGlass10
-  category: JobsEngineeringSeniorEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - SheetRUGlass10
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentSheetPGlass
-  category: JobsEngineeringSeniorEngineer
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - SheetPGlass
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentSheetPGlass10
-  category: JobsEngineeringSeniorEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - SheetPGlass10
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentSheetRPGlass
-  category: JobsEngineeringSeniorEngineer
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - SheetRPGlass
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentSheetRPGlass10
-  category: JobsEngineeringSeniorEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - SheetRPGlass10
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentSheetClockworkGlass
-  category: JobsEngineeringSeniorEngineer
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - SheetClockworkGlass
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentSheetClockworkGlass10
-  category: JobsEngineeringSeniorEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - SheetClockworkGlass10
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentSheetPlastic
-  category: JobsEngineeringSeniorEngineer
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - SheetPlastic
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentSheetPlastic10
-  category: JobsEngineeringSeniorEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items:
-    - SheetPlastic10
-
-- type: loadout
-  id: LoadoutSeniorEngineerEquipmentExperimentalWeldingTool
-  category: JobsEngineeringSeniorEngineer
-  cost: 0
-  requirements: 
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorEngineerEquipmentExtra
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorEngineer
-  items: 
-    - WelderExperimental
 # Eyes
 
 # Gloves

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/stationEngineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/stationEngineer.yml
@@ -6,175 +6,178 @@
 # Ears
 
 # Equipment
-- type: loadout
-  id: LoadoutStationEngineerEquipmentBoxInflatable
-  category: JobsEngineeringStationEngineer
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutStationEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - StationEngineer
-  items:
-    - BoxInflatable
 
-- type: loadout
-  id: LoadoutStationEngineerEquipmentRCD
-  category: JobsEngineeringStationEngineer
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutStationEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - StationEngineer
-  items:
-    - RCD
-    - RCDAmmo
-
-- type: loadout
-  id: LoadoutStationEngineerEquipmentPowerDrill
-  category: JobsEngineeringStationEngineer
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutStationEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - StationEngineer
-  items:
-    - PowerDrill
-
-- type: loadout
-  id: LoadoutStationEngineerEquipmentSheetSteel
-  category: JobsEngineeringStationEngineer
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutStationEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - StationEngineer
-  items:
-    - SheetSteel
-
-- type: loadout
-  id: LoadoutStationEngineerEquipmentSheetSteel10
-  category: JobsEngineeringStationEngineer
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutStationEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - StationEngineer
-  items:
-    - SheetSteel10
-
-- type: loadout
-  id: LoadoutStationEngineerEquipmentSheetPlasteel
-  category: JobsEngineeringStationEngineer
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutStationEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - StationEngineer
-  items:
-    - SheetPlasteel
-
-- type: loadout
-  id: LoadoutStationEngineerEquipmentSheetPlasteel10
-  category: JobsEngineeringStationEngineer
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutStationEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - StationEngineer
-  items:
-    - SheetPlasteel10
-
-- type: loadout
-  id: LoadoutStationEngineerEquipmentSheetGlass
-  category: JobsEngineeringStationEngineer
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutStationEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - StationEngineer
-  items:
-    - SheetGlass
-
-- type: loadout
-  id: LoadoutStationEngineerEquipmentSheetGlass10
-  category: JobsEngineeringStationEngineer
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutStationEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - StationEngineer
-  items:
-    - SheetGlass10
-
-- type: loadout
-  id: LoadoutStationEngineerEquipmentMaterialWoodPlank
-  category: JobsEngineeringStationEngineer
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutStationEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - StationEngineer
-  items:
-    - MaterialWoodPlank
-
-- type: loadout
-  id: LoadoutStationEngineerEquipmentMaterialWoodPlank10
-  category: JobsEngineeringStationEngineer
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutStationEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - StationEngineer
-  items:
-    - MaterialWoodPlank10
-
-- type: loadout
-  id: LoadoutStationEngineerEquipmentSheetPlastic
-  category: JobsEngineeringStationEngineer
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutStationEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - StationEngineer
-  items:
-    - SheetPlastic
-
-- type: loadout
-  id: LoadoutStationEngineerEquipmentSheetPlastic10
-  category: JobsEngineeringStationEngineer
-  cost: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutStationEngineerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - StationEngineer
-  items:
-    - SheetPlastic10
+# WWDP edit start - no roundstart loot
+# - type: loadout
+#   id: LoadoutStationEngineerEquipmentBoxInflatable
+#   category: JobsEngineeringStationEngineer
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutStationEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - StationEngineer
+#   items:
+#     - BoxInflatable
+#
+# - type: loadout
+#   id: LoadoutStationEngineerEquipmentRCD
+#   category: JobsEngineeringStationEngineer
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutStationEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - StationEngineer
+#   items:
+#     - RCD
+#     - RCDAmmo
+#
+# - type: loadout
+#   id: LoadoutStationEngineerEquipmentPowerDrill
+#   category: JobsEngineeringStationEngineer
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutStationEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - StationEngineer
+#   items:
+#     - PowerDrill
+#
+# - type: loadout
+#   id: LoadoutStationEngineerEquipmentSheetSteel
+#   category: JobsEngineeringStationEngineer
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutStationEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - StationEngineer
+#   items:
+#     - SheetSteel
+#
+# - type: loadout
+#   id: LoadoutStationEngineerEquipmentSheetSteel10
+#   category: JobsEngineeringStationEngineer
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutStationEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - StationEngineer
+#   items:
+#     - SheetSteel10
+#
+# - type: loadout
+#   id: LoadoutStationEngineerEquipmentSheetPlasteel
+#   category: JobsEngineeringStationEngineer
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutStationEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - StationEngineer
+#   items:
+#     - SheetPlasteel
+#
+# - type: loadout
+#   id: LoadoutStationEngineerEquipmentSheetPlasteel10
+#   category: JobsEngineeringStationEngineer
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutStationEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - StationEngineer
+#   items:
+#     - SheetPlasteel10
+#
+# - type: loadout
+#   id: LoadoutStationEngineerEquipmentSheetGlass
+#   category: JobsEngineeringStationEngineer
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutStationEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - StationEngineer
+#   items:
+#     - SheetGlass
+#
+# - type: loadout
+#   id: LoadoutStationEngineerEquipmentSheetGlass10
+#   category: JobsEngineeringStationEngineer
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutStationEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - StationEngineer
+#   items:
+#     - SheetGlass10
+#
+# - type: loadout
+#   id: LoadoutStationEngineerEquipmentMaterialWoodPlank
+#   category: JobsEngineeringStationEngineer
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutStationEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - StationEngineer
+#   items:
+#     - MaterialWoodPlank
+#
+# - type: loadout
+#   id: LoadoutStationEngineerEquipmentMaterialWoodPlank10
+#   category: JobsEngineeringStationEngineer
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutStationEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - StationEngineer
+#   items:
+#     - MaterialWoodPlank10
+#
+# - type: loadout
+#   id: LoadoutStationEngineerEquipmentSheetPlastic
+#   category: JobsEngineeringStationEngineer
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutStationEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - StationEngineer
+#   items:
+#     - SheetPlastic
+#
+# - type: loadout
+#   id: LoadoutStationEngineerEquipmentSheetPlastic10
+#   category: JobsEngineeringStationEngineer
+#   cost: 1
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutStationEngineerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - StationEngineer
+#   items:
+#     - SheetPlastic10
+# WWDP edit end
 
 # Eyes
 

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/technicalAssistant.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/technicalAssistant.yml
@@ -6,84 +6,87 @@
 # Ears
 
 # Equipment
-- type: loadout
-  id: LoadoutTechnicalAssistantEquipmentBoxInflatable
-  category: JobsEngineeringTechnicalAssistant
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutTechnicalAssistantEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - TechnicalAssistant
-  items:
-    - BoxInflatable
 
-- type: loadout
-  id: LoadoutTechnicalAssistantEquipmentSheetSteel10
-  category: JobsEngineeringTechnicalAssistant
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutTechnicalAssistantEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - TechnicalAssistant
-  items:
-    - SheetSteel10
-
-- type: loadout
-  id: LoadoutTechnicalAssistantEquipmentSheetPlasteel10
-  category: JobsEngineeringTechnicalAssistant
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutTechnicalAssistantEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - TechnicalAssistant
-  items:
-    - SheetPlasteel10
-
-- type: loadout
-  id: LoadoutTechnicalAssistantEquipmentSheetGlass10
-  category: JobsEngineeringTechnicalAssistant
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutTechnicalAssistantEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - TechnicalAssistant
-  items:
-    - SheetGlass10
-
-- type: loadout
-  id: LoadoutTechnicalAssistantEquipmentMaterialWoodPlank10
-  category: JobsEngineeringTechnicalAssistant
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutTechnicalAssistantEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - TechnicalAssistant
-  items:
-    - MaterialWoodPlank10
-
-
-- type: loadout
-  id: LoadoutTechnicalAssistantEquipmentSheetPlastic10
-  category: JobsEngineeringTechnicalAssistant
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutTechnicalAssistantEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - TechnicalAssistant
-  items:
-    - SheetPlastic10
+# WWDP edit start - no roundstart loot
+# - type: loadout
+#   id: LoadoutTechnicalAssistantEquipmentBoxInflatable
+#   category: JobsEngineeringTechnicalAssistant
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutTechnicalAssistantEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - TechnicalAssistant
+#   items:
+#     - BoxInflatable
+#
+# - type: loadout
+#   id: LoadoutTechnicalAssistantEquipmentSheetSteel10
+#   category: JobsEngineeringTechnicalAssistant
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutTechnicalAssistantEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - TechnicalAssistant
+#   items:
+#     - SheetSteel10
+#
+# - type: loadout
+#   id: LoadoutTechnicalAssistantEquipmentSheetPlasteel10
+#   category: JobsEngineeringTechnicalAssistant
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutTechnicalAssistantEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - TechnicalAssistant
+#   items:
+#     - SheetPlasteel10
+#
+# - type: loadout
+#   id: LoadoutTechnicalAssistantEquipmentSheetGlass10
+#   category: JobsEngineeringTechnicalAssistant
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutTechnicalAssistantEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - TechnicalAssistant
+#   items:
+#     - SheetGlass10
+#
+# - type: loadout
+#   id: LoadoutTechnicalAssistantEquipmentMaterialWoodPlank10
+#   category: JobsEngineeringTechnicalAssistant
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutTechnicalAssistantEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - TechnicalAssistant
+#   items:
+#     - MaterialWoodPlank10
+#
+#
+# - type: loadout
+#   id: LoadoutTechnicalAssistantEquipmentSheetPlastic10
+#   category: JobsEngineeringTechnicalAssistant
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutTechnicalAssistantEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - TechnicalAssistant
+#   items:
+#     - SheetPlastic10
+# WWDP edit end
 
 # Eyes
 

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/traitRestrictedGear.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/traitRestrictedGear.yml
@@ -1,220 +1,223 @@
-### All Engineers
-## Mesons
-- type: loadout
-  id: LoadoutEngineeringRestrictedGearEyesMeson
-  category: JobsEngineeringAAUncategorized
-  cost: 2
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutEyesEngineering
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Engineering
-  items:
-    - ClothingEyesGlassesMeson
-
-## Tools
-# Wirecutter
-- type: loadout
-  id: LoadoutEngineeringRestrictedGearEquipmentWirecutter
-  category: JobsEngineeringAAUncategorized
-  cost: 1
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Engineering
-  items:
-    - Wirecutter
-
-# Screwdriver
-- type: loadout
-  id: LoadoutEngineeringRestrictedGearEquipmentScrewdriver
-  category: JobsEngineeringAAUncategorized
-  cost: 1
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Engineering
-  items:
-    - Screwdriver
-
-# Wrench
-- type: loadout
-  id: LoadoutEngineeringRestrictedGearEquipmentWrench
-  category: JobsEngineeringAAUncategorized
-  cost: 1
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Engineering
-  items:
-    - Wrench
-
-# White Crowbar
-- type: loadout
-  id: LoadoutEngineeringRestrictedGearEquipmentCrowbar
-  category: JobsEngineeringAAUncategorized
-  cost: 1
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Engineering
-  items:
-    - Crowbar
-
-# Multitool
-- type: loadout
-  id: LoadoutEngineeringRestrictedGearEquipmentMultitool
-  category: JobsEngineeringAAUncategorized
-  cost: 2
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Engineering
-  items:
-    - Multitool
-
-# Power Drill
-- type: loadout
-  id: LoadoutEngineeringRestrictedGearPowerDrill
-  category: JobsEngineeringAAUncategorized
-  cost: 3
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Engineering
-  items:
-    - PowerDrill
-
-## Insulated Gloves Variations
-# Yellow
-- type: loadout
-  id: LoadoutEngineeringRestrictedGearGlovesInsulated
-  category: JobsEngineeringAAUncategorized
-  cost: 5
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutEngineeringGloves
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Engineering
-  items:
-    - ClothingHandsGlovesColorYellow
-
-# Black
-- type: loadout
-  id: LoadoutEngineeringRestrictedGearGlovesCombat
-  category: JobsEngineeringAAUncategorized
-  cost: 5
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutEngineeringGloves
-    # not inverted for engineers because loadout may be removed in pr 2105
-  items:
-    - ClothingHandsGlovesCombat
-
-# Merc
-- type: loadout
-  id: LoadoutEngineeringRestrictedGearGlovesMerc
-  category: JobsEngineeringAAUncategorized
-  cost: 5
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutEngineeringGloves
-    # not inverted for engineers because loadout may be removed in pr 2105
-  items:
-    - ClothingHandsMercGlovesCombat
-
-
-### Atmos
-## Utility belt
-- type: loadout
-  id: LoadoutEngineeringRestrictedGearBeltUtilityAtmos
-  category: JobsEngineeringAtmosphericTechnician
-  cost: 5
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - AtmosphericTechnician
-  items:
-    - ClothingBeltUtilityAtmos
-
-- type: loadout
-  id: LoadoutEngineeringRestrictedGearEquipmentHolofanProjector
-  category: JobsEngineeringAtmosphericTechnician
-  cost: 1
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - AtmosphericTechnician
-  items:
-    - HolofanProjector
-
-### SE
-## Utility belt
-- type: loadout
-  id: LoadoutEngineeringRestrictedGearBeltUtilityEngineering
-  category: JobsEngineeringStationEngineer
-  cost: 4
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - StationEngineer
-  items:
-    - ClothingBeltUtilityEngineering
+# WWDP EDIT START - TRAIT REMOVED
+#
+# ### All Engineers
+# ## Mesons
+# - type: loadout
+#   id: LoadoutEngineeringRestrictedGearEyesMeson
+#   category: JobsEngineeringAAUncategorized
+#   cost: 2
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutEyesEngineering
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Engineering
+#   items:
+#     - ClothingEyesGlassesMeson
+#
+# ## Tools
+# # Wirecutter
+# - type: loadout
+#   id: LoadoutEngineeringRestrictedGearEquipmentWirecutter
+#   category: JobsEngineeringAAUncategorized
+#   cost: 1
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Engineering
+#   items:
+#     - Wirecutter
+#
+# # Screwdriver
+# - type: loadout
+#   id: LoadoutEngineeringRestrictedGearEquipmentScrewdriver
+#   category: JobsEngineeringAAUncategorized
+#   cost: 1
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Engineering
+#   items:
+#     - Screwdriver
+#
+# # Wrench
+# - type: loadout
+#   id: LoadoutEngineeringRestrictedGearEquipmentWrench
+#   category: JobsEngineeringAAUncategorized
+#   cost: 1
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Engineering
+#   items:
+#     - Wrench
+#
+# # White Crowbar
+# - type: loadout
+#   id: LoadoutEngineeringRestrictedGearEquipmentCrowbar
+#   category: JobsEngineeringAAUncategorized
+#   cost: 1
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Engineering
+#   items:
+#     - Crowbar
+#
+# # Multitool
+# - type: loadout
+#   id: LoadoutEngineeringRestrictedGearEquipmentMultitool
+#   category: JobsEngineeringAAUncategorized
+#   cost: 2
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Engineering
+#   items:
+#     - Multitool
+#
+# # Power Drill
+# - type: loadout
+#   id: LoadoutEngineeringRestrictedGearPowerDrill
+#   category: JobsEngineeringAAUncategorized
+#   cost: 3
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Engineering
+#   items:
+#     - PowerDrill
+#
+# ## Insulated Gloves Variations
+# # Yellow
+# - type: loadout
+#   id: LoadoutEngineeringRestrictedGearGlovesInsulated
+#   category: JobsEngineeringAAUncategorized
+#   cost: 5
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutEngineeringGloves
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Engineering
+#   items:
+#     - ClothingHandsGlovesColorYellow
+#
+# # Black
+# - type: loadout
+#   id: LoadoutEngineeringRestrictedGearGlovesCombat
+#   category: JobsEngineeringAAUncategorized
+#   cost: 5
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutEngineeringGloves
+#     # not inverted for engineers because loadout may be removed in pr 2105
+#   items:
+#     - ClothingHandsGlovesCombat
+#
+# # Merc
+# - type: loadout
+#   id: LoadoutEngineeringRestrictedGearGlovesMerc
+#   category: JobsEngineeringAAUncategorized
+#   cost: 5
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutEngineeringGloves
+#     # not inverted for engineers because loadout may be removed in pr 2105
+#   items:
+#     - ClothingHandsMercGlovesCombat
+#
+#
+# ### Atmos
+# ## Utility belt
+# - type: loadout
+#   id: LoadoutEngineeringRestrictedGearBeltUtilityAtmos
+#   category: JobsEngineeringAtmosphericTechnician
+#   cost: 5
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - AtmosphericTechnician
+#   items:
+#     - ClothingBeltUtilityAtmos
+#
+# - type: loadout
+#   id: LoadoutEngineeringRestrictedGearEquipmentHolofanProjector
+#   category: JobsEngineeringAtmosphericTechnician
+#   cost: 1
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - AtmosphericTechnician
+#   items:
+#     - HolofanProjector
+#
+# ### SE
+# ## Utility belt
+# - type: loadout
+#   id: LoadoutEngineeringRestrictedGearBeltUtilityEngineering
+#   category: JobsEngineeringStationEngineer
+#   cost: 4
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - StationEngineer
+#   items:
+#     - ClothingBeltUtilityEngineering
+# WWDP edit end

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/uncategorized.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/uncategorized.yml
@@ -63,19 +63,21 @@
     - ClothingEyesGlassesMeson
 
 # Gloves
-- type: loadout
-  id: LoadoutEngineeringGlovesInsulated
-  category: JobsEngineeringAAUncategorized
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutEngineeringGloves
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Engineering
-  items:
-    - ClothingHandsGlovesColorYellow
+
+# WWDP disabled
+# - type: loadout
+#   id: LoadoutEngineeringGlovesInsulated
+#   category: JobsEngineeringAAUncategorized
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutEngineeringGloves
+#     - !type:CharacterDepartmentRequirement
+#       departments:
+#         - Engineering
+#   items:
+#     - ClothingHandsGlovesColorYellow
 
 # Head
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/cataloger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/cataloger.yml
@@ -60,33 +60,35 @@
     - PillCanisterSpaceDrugs
 
 # Eyes
-- type: loadout
-  id: LoadoutCatalogerEyesEpiHUD
-  category: JobsEpistemicsCataloger
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutCatalogerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - Librarian
-  items:
-    - ClothingEyesHudEpistemics
-
-- type: loadout
-  id: LoadoutCatalogerEyesEpiGlasses
-  category: JobsEpistemicsCataloger
-  cost: 3
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutCatalogerEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - Librarian
-  items:
-    - ClothingEyesGlassesEpistemics
+# WWDP edit start - disabled/moved to locker
+# - type: loadout
+#   id: LoadoutCatalogerEyesEpiHUD
+#   category: JobsEpistemicsCataloger
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutCatalogerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Librarian
+#   items:
+#     - ClothingEyesHudEpistemics
+#
+# - type: loadout
+#   id: LoadoutCatalogerEyesEpiGlasses
+#   category: JobsEpistemicsCataloger
+#   cost: 3
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutCatalogerEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Librarian
+#   items:
+#     - ClothingEyesGlassesEpistemics
+# WWDP edit end
 
 # Gloves
 

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/chaplain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/chaplain.yml
@@ -6,33 +6,37 @@
 # Ears
 
 # Equipment
-- type: loadout
-  id: LoadoutChaplainBible
-  category: JobsEpistemicsChaplain
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChaplainEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - Chaplain
-  items:
-    - Bible
 
-- type: loadout
-  id: LoadoutChaplainStamp
-  category: JobsEpistemicsChaplain
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChaplainEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - Chaplain
-  items:
-    - RubberStampChaplain
+# WWDP edit start - moved to starting items
+# - type: loadout
+#   id: LoadoutChaplainBible
+#   category: JobsEpistemicsChaplain
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChaplainEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Chaplain
+#   items:
+#     - Bible
+#
+# - type: loadout
+#   id: LoadoutChaplainStamp
+#   category: JobsEpistemicsChaplain
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChaplainEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Chaplain
+#   items:
+#     - RubberStampChaplainRubberStampChaplain
+#
+# WWDP edit end
 
 - type: loadout
   id: LoadoutChaplainEquipmentCandles
@@ -75,33 +79,35 @@
     - PillCanisterSpaceDrugs
 
 # Eyes
-- type: loadout
-  id: LoadoutChaplainEyesEpiHUD
-  category: JobsEpistemicsChaplain
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChaplainEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - Chaplain
-  items:
-    - ClothingEyesHudEpistemics
-
-- type: loadout
-  id: LoadoutChaplainEyesEpiGlasses
-  category: JobsEpistemicsChaplain
-  cost: 3
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChaplainEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - Chaplain
-  items:
-    - ClothingEyesGlassesEpistemics
+# WWDP edit start - disabled/moved to locker
+# - type: loadout
+#   id: LoadoutChaplainEyesEpiHUD
+#   category: JobsEpistemicsChaplain
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChaplainEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Chaplain
+#   items:
+#     - ClothingEyesHudEpistemics
+#
+# - type: loadout
+#   id: LoadoutChaplainEyesEpiGlasses
+#   category: JobsEpistemicsChaplain
+#   cost: 3
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChaplainEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Chaplain
+#   items:
+#     - ClothingEyesGlassesEpistemics
+# WWDP edit end
 
 # Gloves
 

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/golemancer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/golemancer.yml
@@ -44,19 +44,21 @@
 
 
 # Belt
-- type: loadout
-  id: LoadoutGolemancerBeltUtility
-  category: JobsEpistemicsGolemancer
-  cost: 3
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutGolemancerBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - Roboticist
-  items:
-    - ClothingBeltUtilityFilled
+# WWDP edit start
+# - type: loadout
+#   id: LoadoutGolemancerBeltUtility
+#   category: JobsEpistemicsGolemancer
+#   cost: 3
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutGolemancerBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Roboticist
+#   items:
+#     - ClothingBeltUtilityFilled
+# WWDP edit end
 
 # Ears
 

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/mystagogue.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/mystagogue.yml
@@ -88,33 +88,35 @@
     - PillCanisterSpaceDrugs
 
 # Eyes
-- type: loadout
-  id: LoadoutMystagogueEyesEpiHUD
-  category: JobsEpistemicsMystagogue
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMystagogueEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ResearchDirector
-  items:
-    - ClothingEyesHudEpistemics
-
-- type: loadout
-  id: LoadoutMystagogueEyesEpiGlasses
-  category: JobsEpistemicsMystagogue
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMystagogueEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ResearchDirector
-  items:
-    - ClothingEyesGlassesEpistemics
+# WWDP edit start - moved to locker
+# - type: loadout
+#   id: LoadoutMystagogueEyesEpiHUD
+#   category: JobsEpistemicsMystagogue
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMystagogueEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ResearchDirector
+#   items:
+#     - ClothingEyesHudEpistemics
+#
+# - type: loadout
+#   id: LoadoutMystagogueEyesEpiGlasses
+#   category: JobsEpistemicsMystagogue
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMystagogueEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ResearchDirector
+#   items:
+#     - ClothingEyesGlassesEpistemics
+# WWDP edit end
 
 # Gloves
 

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/psionicMantis.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/psionicMantis.yml
@@ -61,34 +61,35 @@
     - PillCanisterCryptobiolin
 
 # Eyes
-- type: loadout
-  id: LoadoutPsionicMantisEyesEpiHUD
-  category: JobsEpistemicsPsionicMantis
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutPsionicMantisEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ForensicMantis
-  items:
-    - ClothingEyesHudEpistemics
-
-- type: loadout
-  id: LoadoutPsionicMantisEyesEpiGlasses
-  category: JobsEpistemicsPsionicMantis
-  cost: 3
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutPsionicMantisEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - ForensicMantis
-  items:
-    - ClothingEyesGlassesEpistemics
-
+# WWDP edit start - disabled/moved to locker
+# - type: loadout
+#   id: LoadoutPsionicMantisEyesEpiHUD
+#   category: JobsEpistemicsPsionicMantis
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutPsionicMantisEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ForensicMantis
+#   items:
+#     - ClothingEyesHudEpistemics
+#
+# - type: loadout
+#   id: LoadoutPsionicMantisEyesEpiGlasses
+#   category: JobsEpistemicsPsionicMantis
+#   cost: 3
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutPsionicMantisEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ForensicMantis
+#   items:
+#     - ClothingEyesGlassesEpistemics
+# WWDP edit end
 
 # Gloves
 

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/traitRestrictedGear.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/traitRestrictedGear.yml
@@ -1,39 +1,43 @@
-### All Epistemiologists
-## Eyes
-# Hud
-- type: loadout
-  id: LoadoutScienceRestrictedGearEyesHudDiagnostic
-  category: JobsEpistemicsAAUncategorized
-  cost: 2
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutEpistemicsEyes
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Epistemics
-  items:
-    - ClothingEyesHudDiagnostic
-
-# Eyepatch
-- type: loadout
-  id: LoadoutScienceRestrictedGearEyesEyepatchHudDiag
-  category: JobsEpistemicsAAUncategorized
-  cost: 2
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutEpistemicsEyes
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Epistemics
-  items:
-    - ClothingEyesEyepatchHudDiag
+# WWDP edit start - trait removed
+#
+# ### All Epistemiologists
+# ## Eyes
+# # Hud
+# - type: loadout
+#   id: LoadoutScienceRestrictedGearEyesHudDiagnostic
+#   category: JobsEpistemicsAAUncategorized
+#   cost: 2
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutEpistemicsEyes
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Epistemics
+#   items:
+#     - ClothingEyesHudDiagnostic
+#
+# # Eyepatch
+# - type: loadout
+#   id: LoadoutScienceRestrictedGearEyesEyepatchHudDiag
+#   category: JobsEpistemicsAAUncategorized
+#   cost: 2
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutEpistemicsEyes
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Epistemics
+#   items:
+#     - ClothingEyesEyepatchHudDiag
+#
+# WWDP edit end

--- a/Resources/Prototypes/Loadouts/Jobs/Logistics/salvageSpecialist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Logistics/salvageSpecialist.yml
@@ -46,214 +46,220 @@
         - SalvageSpecialist
 
 # Belt
-- type: loadout
-  id: LoadoutSalvageBeltMercWebbing
-  category: JobsLogisticsSalvageSpecialist
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - SalvageSpecialist
-  items:
-    - ClothingBeltMercWebbing
 
-- type: loadout
-  id: LoadoutSalvageBeltSalvageWebbing
-  category: JobsLogisticsSalvageSpecialist
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - SalvageSpecialist
-  items:
-    - ClothingBeltSalvageWebbing
-
-- type: loadout
-  id: LoadoutSalvageBeltMilitaryWebbing
-  category: JobsLogisticsSalvageSpecialist
-  cost: 0
-  customColorTint: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - SalvageSpecialist
-  items:
-    - ClothingBeltMilitaryWebbing
+# WWDP edit start - disabled
+# - type: loadout
+#   id: LoadoutSalvageBeltMercWebbing
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - ClothingBeltMercWebbing
+#
+# - type: loadout
+#   id: LoadoutSalvageBeltSalvageWebbing
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - ClothingBeltSalvageWebbing
+#
+# - type: loadout
+#   id: LoadoutSalvageBeltMilitaryWebbing
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 0
+#   customColorTint: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - ClothingBeltMilitaryWebbing
+# WWDP edit end
 
 # Ears
 
 # Equipment
-- type: loadout
-  id: LoadoutCargoWeaponsCrusherDagger
-  category: JobsLogisticsSalvageSpecialist
-  cost: 2
-  canBeHeirloom: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      jobs:
-        - SalvageSpecialist
-  items:
-    - WeaponCrusherDagger
 
-- type: loadout
-  id: LoadoutSalvageWeaponsCombatKnife
-  category: JobsLogisticsSalvageSpecialist
-  cost: 0
-  canBeHeirloom: true
-  customColorTint: true # Go read Neuromancer
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      jobs:
-        - SalvageSpecialist
-  items:
-    - CombatKnife
-
-- type: loadout
-  id: LoadoutSalvageWeaponsKitchenKnife
-  category: JobsLogisticsSalvageSpecialist
-  cost: 0
-  canBeHeirloom: true
-  customColorTint: true # Go read Neuromancer
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      jobs:
-        - SalvageSpecialist
-  items:
-    - KitchenKnife
-
-- type: loadout
-  id: LoadoutSalvageWeaponsSurvivalKnife
-  category: JobsLogisticsSalvageSpecialist
-  cost: 0
-  canBeHeirloom: true
-  customColorTint: true # Go read Neuromancer
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      jobs:
-        - SalvageSpecialist
-  items:
-    - SurvivalKnife
-
-- type: loadout
-  id: LoadoutSalvageWeaponsKukriKnife
-  category: JobsLogisticsSalvageSpecialist
-  cost: 0
-  canBeHeirloom: true
-  customColorTint: true # Go read Neuromancer
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      jobs:
-        - SalvageSpecialist
-  items:
-    - KukriKnife
-
-- type: loadout
-  id: LoadoutSalvageWeaponsCleaver
-  category: JobsLogisticsSalvageSpecialist
-  cost: 0
-  canBeHeirloom: true
-  customColorTint: true # Go read Neuromancer
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      jobs:
-        - SalvageSpecialist
-  items:
-    - ButchCleaver
-
-- type: loadout
-  id: LoadoutSalvageWeaponsThrowingKnife
-  category: JobsLogisticsSalvageSpecialist
-  cost: 1
-  canBeHeirloom: true
-  customColorTint: true # Go read Neuromancer
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      jobs:
-        - SalvageSpecialist
-  items:
-    - ThrowingKnife
-    - ThrowingKnife
-    - ThrowingKnife
-
-- type: loadout
-  id: LoadoutSalvageWeaponsMachete
-  category: JobsLogisticsSalvageSpecialist
-  cost: 1
-  canBeHeirloom: true
-  customColorTint: true # Go read Neuromancer
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      jobs:
-        - SalvageSpecialist
-  items:
-    - Machete
-
-- type: loadout
-  id: LoadoutSalvageWeaponsCutlass
-  category: JobsLogisticsSalvageSpecialist
-  cost: 2
-  canBeHeirloom: true
-  customColorTint: true # Go read Neuromancer
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      jobs:
-        - SalvageSpecialist
-  items:
-    - Cutlass
-
-- type: loadout
-  id: LoadoutSalvageWeaponsKatana
-  category: JobsLogisticsSalvageSpecialist
-  cost: 2
-  canBeHeirloom: true
-  customColorTint: true # Go read Neuromancer
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      jobs:
-        - SalvageSpecialist
-  items:
-    - Katana
-
-- type: loadout
-  id: LoadoutSalvageWeaponsWakizashi
-  category: JobsLogisticsSalvageSpecialist
-  cost: 1
-  canBeHeirloom: true
-  customColorTint: true # Go read Neuromancer
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      jobs:
-        - SalvageSpecialist
-  items:
-    - Wakizashi
+# WWDP edit start - moved all the shit to lockers
+# - type: loadout
+#   id: LoadoutCargoWeaponsCrusherDagger
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 2
+#   canBeHeirloom: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - WeaponCrusherDagger
+#
+# - type: loadout
+#   id: LoadoutSalvageWeaponsCombatKnife
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 0
+#   canBeHeirloom: true
+#   customColorTint: true # Go read Neuromancer
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - CombatKnife
+#
+# - type: loadout
+#   id: LoadoutSalvageWeaponsKitchenKnife
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 0
+#   canBeHeirloom: true
+#   customColorTint: true # Go read Neuromancer
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - KitchenKnife
+#
+# - type: loadout
+#   id: LoadoutSalvageWeaponsSurvivalKnife
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 0
+#   canBeHeirloom: true
+#   customColorTint: true # Go read Neuromancer
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - SurvivalKnife
+#
+# - type: loadout
+#   id: LoadoutSalvageWeaponsKukriKnife
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 0
+#   canBeHeirloom: true
+#   customColorTint: true # Go read Neuromancer
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - KukriKnife
+#
+# - type: loadout
+#   id: LoadoutSalvageWeaponsCleaver
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 0
+#   canBeHeirloom: true
+#   customColorTint: true # Go read Neuromancer
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - ButchCleaver
+#
+# - type: loadout
+#   id: LoadoutSalvageWeaponsThrowingKnife
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 1
+#   canBeHeirloom: true
+#   customColorTint: true # Go read Neuromancer
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - ThrowingKnife
+#     - ThrowingKnife
+#     - ThrowingKnife
+#
+# - type: loadout
+#   id: LoadoutSalvageWeaponsMachete
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 1
+#   canBeHeirloom: true
+#   customColorTint: true # Go read Neuromancer
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - Machete
+#
+# - type: loadout
+#   id: LoadoutSalvageWeaponsCutlass
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 2
+#   canBeHeirloom: true
+#   customColorTint: true # Go read Neuromancer
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - Cutlass
+#
+# - type: loadout
+#   id: LoadoutSalvageWeaponsKatana
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 2
+#   canBeHeirloom: true
+#   customColorTint: true # Go read Neuromancer
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - Katana
+#
+# - type: loadout
+#   id: LoadoutSalvageWeaponsWakizashi
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 1
+#   canBeHeirloom: true
+#   customColorTint: true # Go read Neuromancer
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - Wakizashi
+# WWDP edit end
 
 # Eyes
 

--- a/Resources/Prototypes/Loadouts/Jobs/Logistics/traitRestrictedGear.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Logistics/traitRestrictedGear.yml
@@ -1,293 +1,296 @@
-### Salvage Specialist
-## Belts
-# Merc webbing
-- type: loadout
-  id: LoadoutCargoRestrictedGearBeltMercWebbing
-  category: JobsLogisticsSalvageSpecialist
-  cost: 5
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistBelt
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - SalvageSpecialist
-  items:
-    - ClothingBeltMercWebbing
-
-# Salvage rig
-- type: loadout
-  id: LoadoutCargoRestrictedGearBeltSalvageWebbing
-  category: JobsLogisticsSalvageSpecialist
-  cost: 5
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistBelt
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - SalvageSpecialist
-  items:
-    - ClothingBeltSalvageWebbing
-
-# Chest rig
-- type: loadout
-  id: LoadoutCargoRestrictedGearBeltMilitaryWebbing
-  category: JobsLogisticsSalvageSpecialist
-  cost: 5
-  exclusive: true
-  customColorTint: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistBelt
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - SalvageSpecialist
-  items:
-    - ClothingBeltMilitaryWebbing
-
-
-## Weapons
-- type: loadout
-  id: LoadoutCargoRestrictedGearWeaponsCrusherDagger
-  category: JobsLogisticsSalvageSpecialist
-  cost: 5
-  canBeHeirloom: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:OverallTimeRequirement
-      min: 72000 # 20 hours
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - SalvageSpecialist
-  items:
-    - WeaponCrusherDagger
-
-- type: loadout
-  id: LoadoutCargoRestrictedGearWeaponsCombatKnife
-  category: JobsLogisticsSalvageSpecialist
-  cost: 5
-  canBeHeirloom: true
-  customColorTint: true # Go read Neuromancer
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:OverallTimeRequirement
-      min: 72000 # 20 hours
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - SalvageSpecialist
-  items:
-    - CombatKnife
-
-- type: loadout
-  id: LoadoutCargoRestrictedGearWeaponsKitchenKnife
-  category: JobsLogisticsSalvageSpecialist
-  cost: 5
-  canBeHeirloom: true
-  customColorTint: true # Go read Neuromancer
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:OverallTimeRequirement
-      min: 72000 # 20 hours
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - SalvageSpecialist
-  items:
-    - KitchenKnife
-
-- type: loadout
-  id: LoadoutCargoRestrictedGearWeaponsSurvivalKnife
-  category: JobsLogisticsSalvageSpecialist
-  cost: 4
-  canBeHeirloom: true
-  customColorTint: true # Go read Neuromancer
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:OverallTimeRequirement
-      min: 72000 # 20 hours
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - SalvageSpecialist
-  items:
-    - SurvivalKnife
-
-- type: loadout
-  id: LoadoutCargoRestrictedGearWeaponsKukriKnife
-  category: JobsLogisticsSalvageSpecialist
-  cost: 5
-  canBeHeirloom: true
-  customColorTint: true # Go read Neuromancer
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:OverallTimeRequirement
-      min: 72000 # 20 hours
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - SalvageSpecialist
-  items:
-    - KukriKnife
-
-- type: loadout
-  id: LoadoutCargoRestrictedGearWeaponsCleaver
-  category: JobsLogisticsSalvageSpecialist
-  cost: 5
-  canBeHeirloom: true
-  customColorTint: true # Go read Neuromancer
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:OverallTimeRequirement
-      min: 72000 # 20 hours
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - SalvageSpecialist
-  items:
-    - ButchCleaver
-
-- type: loadout
-  id: LoadoutCargoRestrictedGearWeaponsThrowingKnife
-  category: JobsLogisticsSalvageSpecialist
-  cost: 5
-  canBeHeirloom: true
-  customColorTint: true # Go read Neuromancer
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:OverallTimeRequirement
-      min: 72000 # 20 hours
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - SalvageSpecialist
-  items:
-    - ThrowingKnife
-    - ThrowingKnife
-    - ThrowingKnife
-
-- type: loadout
-  id: LoadoutCargoRestrictedGearWeaponsMachete
-  category: JobsLogisticsSalvageSpecialist
-  cost: 6
-  canBeHeirloom: true
-  customColorTint: true # Go read Neuromancer
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:OverallTimeRequirement
-      min: 72000 # 20 hours
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - SalvageSpecialist
-  items:
-    - Machete
-
-- type: loadout
-  id: LoadoutCargoRestrictedGearWeaponsCutlass
-  category: JobsLogisticsSalvageSpecialist
-  cost: 6
-  canBeHeirloom: true
-  customColorTint: true # Go read Neuromancer
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:OverallTimeRequirement
-      min: 72000 # 20 hours
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - SalvageSpecialist
-  items:
-    - Cutlass
-
-- type: loadout
-  id: LoadoutCargoRestrictedGearWeaponsKatana
-  category: JobsLogisticsSalvageSpecialist
-  cost: 6
-  canBeHeirloom: true
-  customColorTint: true # Go read Neuromancer
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:OverallTimeRequirement
-      min: 72000 # 20 hours
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - SalvageSpecialist
-  items:
-    - Katana
-
-- type: loadout
-  id: LoadoutCargoRestrictedGearWeaponsWakizashi
-  category: JobsLogisticsSalvageSpecialist
-  cost: 5
-  canBeHeirloom: true
-  customColorTint: true # Go read Neuromancer
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:OverallTimeRequirement
-      min: 72000 # 20 hours
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSalvageSpecialistWeapons
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - SalvageSpecialist
-  items:
-    - Wakizashi
+# WWDP edit start - trait removed
+#
+# ### Salvage Specialist
+# ## Belts
+# # Merc webbing
+# - type: loadout
+#   id: LoadoutCargoRestrictedGearBeltMercWebbing
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 5
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistBelt
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - ClothingBeltMercWebbing
+#
+# # Salvage rig
+# - type: loadout
+#   id: LoadoutCargoRestrictedGearBeltSalvageWebbing
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 5
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistBelt
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - ClothingBeltSalvageWebbing
+#
+# # Chest rig
+# - type: loadout
+#   id: LoadoutCargoRestrictedGearBeltMilitaryWebbing
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 5
+#   exclusive: true
+#   customColorTint: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistBelt
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - ClothingBeltMilitaryWebbing
+#
+#
+# ## Weapons
+# - type: loadout
+#   id: LoadoutCargoRestrictedGearWeaponsCrusherDagger
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 5
+#   canBeHeirloom: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:OverallTimeRequirement
+#       min: 72000 # 20 hours
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - WeaponCrusherDagger
+#
+# - type: loadout
+#   id: LoadoutCargoRestrictedGearWeaponsCombatKnife
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 5
+#   canBeHeirloom: true
+#   customColorTint: true # Go read Neuromancer
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:OverallTimeRequirement
+#       min: 72000 # 20 hours
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - CombatKnife
+#
+# - type: loadout
+#   id: LoadoutCargoRestrictedGearWeaponsKitchenKnife
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 5
+#   canBeHeirloom: true
+#   customColorTint: true # Go read Neuromancer
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:OverallTimeRequirement
+#       min: 72000 # 20 hours
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - KitchenKnife
+#
+# - type: loadout
+#   id: LoadoutCargoRestrictedGearWeaponsSurvivalKnife
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 4
+#   canBeHeirloom: true
+#   customColorTint: true # Go read Neuromancer
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:OverallTimeRequirement
+#       min: 72000 # 20 hours
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - SurvivalKnife
+#
+# - type: loadout
+#   id: LoadoutCargoRestrictedGearWeaponsKukriKnife
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 5
+#   canBeHeirloom: true
+#   customColorTint: true # Go read Neuromancer
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:OverallTimeRequirement
+#       min: 72000 # 20 hours
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - KukriKnife
+#
+# - type: loadout
+#   id: LoadoutCargoRestrictedGearWeaponsCleaver
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 5
+#   canBeHeirloom: true
+#   customColorTint: true # Go read Neuromancer
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:OverallTimeRequirement
+#       min: 72000 # 20 hours
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - ButchCleaver
+#
+# - type: loadout
+#   id: LoadoutCargoRestrictedGearWeaponsThrowingKnife
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 5
+#   canBeHeirloom: true
+#   customColorTint: true # Go read Neuromancer
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:OverallTimeRequirement
+#       min: 72000 # 20 hours
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - ThrowingKnife
+#     - ThrowingKnife
+#     - ThrowingKnife
+#
+# - type: loadout
+#   id: LoadoutCargoRestrictedGearWeaponsMachete
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 6
+#   canBeHeirloom: true
+#   customColorTint: true # Go read Neuromancer
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:OverallTimeRequirement
+#       min: 72000 # 20 hours
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - Machete
+#
+# - type: loadout
+#   id: LoadoutCargoRestrictedGearWeaponsCutlass
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 6
+#   canBeHeirloom: true
+#   customColorTint: true # Go read Neuromancer
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:OverallTimeRequirement
+#       min: 72000 # 20 hours
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - Cutlass
+#
+# - type: loadout
+#   id: LoadoutCargoRestrictedGearWeaponsKatana
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 6
+#   canBeHeirloom: true
+#   customColorTint: true # Go read Neuromancer
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:OverallTimeRequirement
+#       min: 72000 # 20 hours
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - Katana
+#
+# - type: loadout
+#   id: LoadoutCargoRestrictedGearWeaponsWakizashi
+#   category: JobsLogisticsSalvageSpecialist
+#   cost: 5
+#   canBeHeirloom: true
+#   customColorTint: true # Go read Neuromancer
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:OverallTimeRequirement
+#       min: 72000 # 20 hours
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSalvageSpecialistWeapons
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - SalvageSpecialist
+#   items:
+#     - Wakizashi
+# WWDP edit end

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/chemist.yml
@@ -71,167 +71,174 @@
   items:
     - HandLabeler
 
-- type: loadout
-  id: LoadoutChemistPillCanisterKelotane
-  category: JobsMedicalChemist
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChemistEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - Chemist
-  items:
-    - PillCanisterKelotane
-
-- type: loadout
-  id: LoadoutChemistPillCanisterTricordrazine
-  category: JobsMedicalChemist
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChemistEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - Chemist
-  items:
-    - PillCanisterTricordrazine
-
-- type: loadout
-  id: LoadoutChemistPillCanisterHyronalin
-  category: JobsMedicalChemist
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChemistEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - Chemist
-  items:
-    - PillCanisterHyronalin
-
-- type: loadout
-  id: LoadoutChemistPillCanisterBicaridine
-  category: JobsMedicalChemist
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChemistEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - Chemist
-  items:
-    - PillCanisterBicaridine
-
-- type: loadout
-  id: LoadoutChemistPillCanisterDermaline
-  category: JobsMedicalChemist
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChemistEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - Chemist
-  items:
-    - PillCanisterDermaline
-
-- type: loadout
-  id: LoadoutChemistPillCanisterDylovene
-  category: JobsMedicalChemist
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChemistEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - Chemist
-  items:
-    - PillCanisterDylovene
-
-- type: loadout
-  id: LoadoutChemistPillCanisterDexalin
-  category: JobsMedicalChemist
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChemistEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - Chemist
-  items:
-    - PillCanisterDexalin
-
-- type: loadout
-  id: LoadoutChemistPillCanisterSpaceDrugs
-  category: JobsMedicalChemist
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChemistEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - Chemist
-  items:
-    - PillCanisterSpaceDrugs
+# WWDP EDIT START - make your own pills!
+#
+# - type: loadout
+#   id: LoadoutChemistPillCanisterKelotane
+#   category: JobsMedicalChemist
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChemistEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Chemist
+#   items:
+#     - PillCanisterKelotane
+#
+# - type: loadout
+#   id: LoadoutChemistPillCanisterTricordrazine
+#   category: JobsMedicalChemist
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChemistEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Chemist
+#   items:
+#     - PillCanisterTricordrazine
+#
+# - type: loadout
+#   id: LoadoutChemistPillCanisterHyronalin
+#   category: JobsMedicalChemist
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChemistEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Chemist
+#   items:
+#     - PillCanisterHyronalin
+#
+# - type: loadout
+#   id: LoadoutChemistPillCanisterBicaridine
+#   category: JobsMedicalChemist
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChemistEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Chemist
+#   items:
+#     - PillCanisterBicaridine
+#
+# - type: loadout
+#   id: LoadoutChemistPillCanisterDermaline
+#   category: JobsMedicalChemist
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChemistEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Chemist
+#   items:
+#     - PillCanisterDermaline
+#
+# - type: loadout
+#   id: LoadoutChemistPillCanisterDylovene
+#   category: JobsMedicalChemist
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChemistEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Chemist
+#   items:
+#     - PillCanisterDylovene
+#
+# - type: loadout
+#   id: LoadoutChemistPillCanisterDexalin
+#   category: JobsMedicalChemist
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChemistEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Chemist
+#   items:
+#     - PillCanisterDexalin
+#
+# - type: loadout
+#   id: LoadoutChemistPillCanisterSpaceDrugs
+#   category: JobsMedicalChemist
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChemistEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Chemist
+#   items:
+#     - PillCanisterSpaceDrugs
+# WWDP edit end
 
 # Eyes
-- type: loadout
-  id: LoadoutMedicalEyesGlassesChemicalBudget
-  category: JobsMedicalChemist
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChemistEyes
-    - !type:CharacterJobRequirement
-      jobs:
-         - Chemist
-  items:
-    - ClothingEyesGlassesChemicalBudget
-
-- type: loadout
-  id: LoadoutMedicalEyesGlassesChemical
-  category: JobsMedicalChemist
-  cost: 2
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChemistEyes
-    - !type:CharacterJobRequirement
-      jobs:
-         - Chemist
-  items:
-    - ClothingEyesGlassesChemical
-
-- type: loadout
-  id: LoadoutMedicalEyesGlassesChemist
-  category: JobsMedicalChemist
-  cost: 1 # These provide caustic armor, oddly enough.
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChemistEyes
-    - !type:CharacterJobRequirement
-       jobs:
-         - Chemist
-  items:
-    - ClothingEyesGlassesChemist
+# WWDP edit start - moved to locker
+# - type: loadout
+#   id: LoadoutMedicalEyesGlassesChemicalBudget
+#   category: JobsMedicalChemist
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChemistEyes
+#     - !type:CharacterJobRequirement
+#       jobs:
+#          - Chemist
+#   items:
+#     - ClothingEyesGlassesChemicalBudget
+#
+# - type: loadout
+#   id: LoadoutMedicalEyesGlassesChemical
+#   category: JobsMedicalChemist
+#   cost: 2
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChemistEyes
+#     - !type:CharacterJobRequirement
+#       jobs:
+#          - Chemist
+#   items:
+#     - ClothingEyesGlassesChemical
+#
+# - type: loadout
+#   id: LoadoutMedicalEyesGlassesChemist
+#   category: JobsMedicalChemist
+#   cost: 1 # These provide caustic armor, oddly enough.
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChemistEyes
+#     - !type:CharacterJobRequirement
+#        jobs:
+#          - Chemist
+#   items:
+#     - ClothingEyesGlassesChemist
+# WWDP edit end
 
 # Gloves
-- type: loadout
-  id: LoadoutMedicalHandsGlovesChemist
-  category: JobsMedicalChemist
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChemistGloves
-    - !type:CharacterJobRequirement
-       jobs:
-         - Chemist
-  items:
-    - ClothingHandsGlovesChemist
+
+# WWDP moved to locker
+# - type: loadout
+#   id: LoadoutMedicalHandsGlovesChemist
+#   category: JobsMedicalChemist
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChemistGloves
+#     - !type:CharacterJobRequirement
+#        jobs:
+#          - Chemist
+#   items:
+#     - ClothingHandsGlovesChemist
 
 # Head
 

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/chiefMedicalOfficer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/chiefMedicalOfficer.yml
@@ -201,7 +201,7 @@
 
 - type: loadout
   id: LoadoutChiefMedicalOfficerShoesLaceup
-  category: JobsCommandCaptain
+  category: JobsMedicalChiefMedicalOfficer
   cost: 0
   exclusive: true
   requirements:
@@ -215,7 +215,7 @@
 
 - type: loadout
   id: LoadoutChiefMedicalOfficerShoesLeather
-  category: JobsCommandCaptain
+  category: JobsMedicalChiefMedicalOfficer
   cost: 0
   exclusive: true
   requirements:

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/chiefMedicalOfficer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/chiefMedicalOfficer.yml
@@ -2,64 +2,70 @@
 # Backpacks
 
 # Belt
-- type: loadout
-  id: LoadoutChiefMedicalOfficerBeltMedical
-  category: JobsMedicalChiefMedicalOfficer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefMedicalOfficerBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefMedicalOfficer
-  items:
-    - ClothingBeltMedical
 
-- type: loadout
-  id: LoadoutChiefMedicalOfficerBeltMedicalAdvancedFilled
-  category: JobsMedicalChiefMedicalOfficer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefMedicalOfficerBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefMedicalOfficer
-  items:
-    - ClothingBeltMedicalAdvancedFilled
-
-- type: loadout
-  id: LoadoutChiefMedicalOfficerBeltMilitaryWebbingCMOFilled
-  category: JobsMedicalChiefMedicalOfficer
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefMedicalOfficerBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefMedicalOfficer
-  items:
-    - ClothingBeltMilitaryWebbingCMOFilled
+# WWDP edit start - moved to lockers
+# - type: loadout
+#   id: LoadoutChiefMedicalOfficerBeltMedical
+#   category: JobsMedicalChiefMedicalOfficer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefMedicalOfficerBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefMedicalOfficer
+#   items:
+#     - ClothingBeltMedical
+#
+# - type: loadout
+#   id: LoadoutChiefMedicalOfficerBeltMedicalAdvancedFilled
+#   category: JobsMedicalChiefMedicalOfficer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefMedicalOfficerBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefMedicalOfficer
+#   items:
+#     - ClothingBeltMedicalAdvancedFilled
+#
+# - type: loadout
+#   id: LoadoutChiefMedicalOfficerBeltMilitaryWebbingCMOFilled
+#   category: JobsMedicalChiefMedicalOfficer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefMedicalOfficerBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - ChiefMedicalOfficer
+#   items:
+#     - ClothingBeltMilitaryWebbingCMOFilled
+# WWDP edit end
 
 # Ears
 
 # Equipment
-- type: loadout
-  id: LoadoutChiefMedicalOfficerEquipmentOmnimedToolLite
-  category: JobsMedicalChiefMedicalOfficer
-  cost: 0
-  exclusive: true
-  requirements:
-  - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefMedicalOfficerEquipment
-  - !type:CharacterJobRequirement
-    jobs:
-      - ChiefMedicalOfficer
-  items:
-    - OmnimedToolLite
+
+# WWDP moved to locker
+# - type: loadout
+#   id: LoadoutChiefMedicalOfficerEquipmentOmnimedToolLite
+#   category: JobsMedicalChiefMedicalOfficer
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#       group: LoadoutChiefMedicalOfficerEquipment
+#   - !type:CharacterJobRequirement
+#     jobs:
+#       - ChiefMedicalOfficer
+#   items:
+#     - OmnimedToolLite
+
 # Eyes
 
 # Gloves

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/medicalDoctor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/medicalDoctor.yml
@@ -2,47 +2,50 @@
 # Backpacks
 
 # Belt
-- type: loadout
-  id: LoadoutMedicalDoctorBeltMedical
-  category: JobsMedicalMedicalDoctor
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMedicalDoctorBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - MedicalDoctor
-  items:
-    - ClothingBeltMedical
 
-- type: loadout
-  id: LoadoutMedicalDoctorBeltMedicalFilled
-  category: JobsMedicalMedicalDoctor
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMedicalDoctorBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - MedicalDoctor
-  items:
-    - ClothingBeltMedicalFilled
-
-- type: loadout
-  id: LoadoutMedicalDoctorBeltMedicalAdvancedFilled
-  category: JobsMedicalMedicalDoctor
-  cost: 2
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMedicalDoctorBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - MedicalDoctor
-  items:
-    - ClothingBeltMedicalAdvancedFilled
+# WWDP edit start - moved to lockers
+# - type: loadout
+#   id: LoadoutMedicalDoctorBeltMedical
+#   category: JobsMedicalMedicalDoctor
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMedicalDoctorBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - MedicalDoctor
+#   items:
+#     - ClothingBeltMedical
+#
+# - type: loadout
+#   id: LoadoutMedicalDoctorBeltMedicalFilled
+#   category: JobsMedicalMedicalDoctor
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMedicalDoctorBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - MedicalDoctor
+#   items:
+#     - ClothingBeltMedicalFilled
+#
+# - type: loadout
+#   id: LoadoutMedicalDoctorBeltMedicalAdvancedFilled
+#   category: JobsMedicalMedicalDoctor
+#   cost: 2
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMedicalDoctorBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - MedicalDoctor
+#   items:
+#     - ClothingBeltMedicalAdvancedFilled
+# WWDP edit end
 
 # Ears
 

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/medicalIntern.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/medicalIntern.yml
@@ -2,33 +2,36 @@
 # Backpacks
 
 # Belt
-- type: loadout
-  id: LoadoutMedicalInternBeltMedical
-  category: JobsMedicalMedicalIntern
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMedicalInternBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - MedicalIntern
-  items:
-    - ClothingBeltMedical
 
-- type: loadout
-  id: LoadoutMedicalInternBeltMedicalFilled
-  category: JobsMedicalMedicalIntern
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMedicalInternBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - MedicalIntern
-  items:
-    - ClothingBeltMedicalFilled
+# WWDP edit start - moved to lockers
+# - type: loadout
+#   id: LoadoutMedicalInternBeltMedical
+#   category: JobsMedicalMedicalIntern
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMedicalInternBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - MedicalIntern
+#   items:
+#     - ClothingBeltMedical
+#
+# - type: loadout
+#   id: LoadoutMedicalInternBeltMedicalFilled
+#   category: JobsMedicalMedicalIntern
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMedicalInternBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - MedicalIntern
+#   items:
+#     - ClothingBeltMedicalFilled
+# WWDP edit end
 
 # Ears
 

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/paramedic.yml
@@ -7,18 +7,19 @@
 
 # Equipment
 
-- type: loadout
-  id: LoadoutParamedicPortafib
-  category: JobsMedicalParamedic
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutParamedicEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - Paramedic
-  items:
-    - Portafib
+# WWDP moved to lockers
+# - type: loadout
+#   id: LoadoutParamedicPortafib
+#   category: JobsMedicalParamedic
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutParamedicEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Paramedic
+#   items:
+#     - Portafib
 
 # Eyes
 

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/psychologist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/psychologist.yml
@@ -49,58 +49,61 @@
 # Equipment
 # The Psychologist chooses freely from drugs that change the mind.
 # If we ever get more mind-affecting drugs, add them here.
-- type: loadout
-  id: LoadoutPsychologistPillCanisterSpaceDrugs
-  category: JobsMedicalPsychologist
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutPsychologistEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - Psychologist
-  items:
-    - PillCanisterSpaceDrugs
 
-- type: loadout
-  id: LoadoutPsychologistPillCanisterPax
-  category: JobsMedicalPsychologist
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutPsychologistEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - Psychologist
-  items:
-    - PillCanisterPax
-
-- type: loadout
-  id: LoadoutPsychologistPillCanisterCryptobiolin
-  category: JobsMedicalPsychologist
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutPsychologistEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - Psychologist
-  items:
-    - PillCanisterCryptobiolin
-
-# Yes this one is a little dangerous. Keeps the job interesting. :)
-- type: loadout
-  id: LoadoutPsychologistPillCanisterChloralHydrate
-  category: JobsMedicalPsychologist
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutPsychologistEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - Psychologist
-  items:
-    - PillCanisterChloralHydrate
+# WWDP edit start - moved to ClothingBackpackPsychologistFilled
+# - type: loadout
+#   id: LoadoutPsychologistPillCanisterSpaceDrugs
+#   category: JobsMedicalPsychologist
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutPsychologistEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Psychologist
+#   items:
+#     - PillCanisterSpaceDrugs
+#
+# - type: loadout
+#   id: LoadoutPsychologistPillCanisterPax
+#   category: JobsMedicalPsychologist
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutPsychologistEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Psychologist
+#   items:
+#     - PillCanisterPax
+#
+# - type: loadout
+#   id: LoadoutPsychologistPillCanisterCryptobiolin
+#   category: JobsMedicalPsychologist
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutPsychologistEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Psychologist
+#   items:
+#     - PillCanisterCryptobiolin
+#
+# # Yes this one is a little dangerous. Keeps the job interesting. :)
+# - type: loadout
+#   id: LoadoutPsychologistPillCanisterChloralHydrate
+#   category: JobsMedicalPsychologist
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutPsychologistEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Psychologist
+#   items:
+#     - PillCanisterChloralHydrate
+# WWDP edit end
 
 # Eyes
 

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/seniorPhysician.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/seniorPhysician.yml
@@ -6,61 +6,65 @@
 # Ears
 
 # Equipment
-- type: loadout
-  id: LoadoutSeniorPhysicianBeltMedical
-  category: JobsMedicalSeniorPhysician
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorPhysicianBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - MedicalDoctor
-  items:
-    - ClothingBeltMedical
 
-- type: loadout
-  id: LoadoutSeniorPhysicianBeltMedicalAdvancedFilled
-  category: JobsMedicalSeniorPhysician
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorPhysicianBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorPhysician
-  items:
-    - ClothingBeltMedicalAdvancedFilled
+# WWDP edit start - moved to lockers
+# - type: loadout
+#   id: LoadoutSeniorPhysicianBeltMedical
+#   category: JobsMedicalSeniorPhysician
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorPhysicianBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - MedicalDoctor
+#   items:
+#     - ClothingBeltMedical
+#
+# - type: loadout
+#   id: LoadoutSeniorPhysicianBeltMedicalAdvancedFilled
+#   category: JobsMedicalSeniorPhysician
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorPhysicianBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorPhysician
+#   items:
+#     - ClothingBeltMedicalAdvancedFilled
+#
+# - type: loadout
+#   id: LoadoutSeniorPhysicianBluespaceBeaker
+#   category: JobsMedicalSeniorPhysician
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorPhysicianToolsExtra
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorPhysician
+#   items:
+#     - BluespaceBeaker
+#
+# - type: loadout
+#   id: LoadoutSeniorPhysicianSurgeryKit
+#   category: JobsMedicalSeniorPhysician
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSeniorPhysicianToolsExtra
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - SeniorPhysician
+#   items:
+#     - FieldSurgeryKit
+# WWDP edit end
 
-- type: loadout
-  id: LoadoutSeniorPhysicianBluespaceBeaker
-  category: JobsMedicalSeniorPhysician
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorPhysicianToolsExtra
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorPhysician
-  items:
-    - BluespaceBeaker
-
-- type: loadout
-  id: LoadoutSeniorPhysicianSurgeryKit
-  category: JobsMedicalSeniorPhysician
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSeniorPhysicianToolsExtra
-    - !type:CharacterJobRequirement
-      jobs:
-        - SeniorPhysician
-  items:
-    - FieldSurgeryKit
 # Eyes
 
 # Gloves

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/traitRestrictedGear.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/traitRestrictedGear.yml
@@ -1,462 +1,466 @@
-### All Medical
-
-## Surgery
-## Note - Would it be more intuitive to move Surgery related items to Medical Doctor?
-## Also, individual surgical tools are also made available as it mightn't always viable to equip the surgical duffel bag
-## Getting the surgical duffel is cheaper than getting all the tools individually
-## However, Scalpel + Hemostat + Retractors + Cautery is only 4 points
-
-# Surgical Duffel
-- type: loadout
-  id: LoadoutMedicalRestrictedGearDuffelSurgeryFilled
-  category: JobsMedicalAUncategorized
-  cost: 5
-  items:
-    - ClothingBackpackDuffelSurgeryFilled
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Medical
-
-# Cautery
-- type: loadout
-  id: LoadoutMedicalRestrictedGearEquipmentCautery
-  category: JobsMedicalAUncategorized
-  cost: 1
-  items:
-    - Cautery
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Medical
-
-# Drill
-- type: loadout
-  id: LoadoutMedicalRestrictedGearEquipmentDrill
-  category: JobsMedicalAUncategorized
-  cost: 1
-  items:
-    - Drill
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Medical
-
-# Scalpel
-- type: loadout
-  id: LoadoutMedicalRestrictedGearEquipmentScalpel
-  category: JobsMedicalAUncategorized
-  cost: 1
-  items:
-    - Scalpel
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Medical
-
-# Retractor
-- type: loadout
-  id: LoadoutMedicalRestrictedGearEquipmentRetractor
-  category: JobsMedicalAUncategorized
-  cost: 1
-  items:
-    - Retractor
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Medical
-
-# Hemostat
-- type: loadout
-  id: LoadoutMedicalRestrictedGearEquipmentHemostat
-  category: JobsMedicalAUncategorized
-  cost: 1
-  items:
-    - Hemostat
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Medical
-
-# Bonesetter
-- type: loadout
-  id: LoadoutMedicalRestrictedGearEquipmentBonesetter
-  category: JobsMedicalAUncategorized
-  cost: 1
-  items:
-    - Bonesetter
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Medical
-
-# Bonegel
-- type: loadout
-  id: LoadoutMedicalRestrictedGearEquipmentBoneGel
-  category: JobsMedicalAUncategorized
-  cost: 1
-  items:
-    - BoneGel
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Medical
-
-# Metal Saw
-- type: loadout
-  id: LoadoutMedicalRestrictedGearEquipmentSaw
-  category: JobsMedicalAUncategorized
-  cost: 1
-  items:
-    - Saw
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Medical
-
-
-## Eyes
-# Medhud
-- type: loadout
-  id: LoadoutMedicalRestrictedGearEyesHudMedical
-  category: JobsMedicalAUncategorized
-  cost: 2
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMedicalEyes
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Medical
-  items:
-    - ClothingEyesHudMedical
-
-# Eyepatch Medhud
-- type: loadout
-  id: LoadoutMedicalRestrictedGearEyepatchHudMedical
-  category: JobsMedicalAUncategorized
-  cost: 2
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMedicalEyes
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Medical
-  items:
-    - ClothingEyesEyepatchHudMedical
-
-# Medhud Prescription
-- type: loadout
-  id: LoadoutMedicalRestrictedGearHudMedicalPrescription
-  category: JobsMedicalAUncategorized
-  cost: 2
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-        - Nearsighted
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMedicalEyes
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Medical
-  items:
-    - ClothingEyesPrescriptionMedHud
-
-## Gloves
-# Nitrile
-- type: loadout
-  id: LoadoutMedicalRestrictedGearGlovesNitrile
-  category: JobsMedicalAUncategorized
-  cost: 1
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMedicalGloves
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Medical
-  items:
-    - ClothingHandsGlovesNitrile
-
-# Latex
-- type: loadout
-  id: LoadoutMedicalRestrictedGearGlovesLatex
-  category: JobsMedicalAUncategorized
-  cost: 1
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutMedicalGloves
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Medical
-  items:
-    - ClothingHandsGlovesLatex
-
-## Stethoscope
-- type: loadout
-  id: LoadoutMedicalRestrictedGearNeckStethoscope
-  category: JobsMedicalAUncategorized
-  cost: 1
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Medical
-  items:
-    - ClothingNeckStethoscope
-
-
-### Chemist
-## Drugs
-# Kelotane
-- type: loadout
-  id: LoadoutMedicalRestrictedGearPillCanisterKelotane
-  category: JobsMedicalChemist
-  cost: 2
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChemistEquipment
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Chemist
-  items:
-    - PillCanisterKelotane
-
-# Tricordrazine
-- type: loadout
-  id: LoadoutMedicalRestrictedGearPillCanisterTricordrazine
-  category: JobsMedicalChemist
-  cost: 1
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChemistEquipment
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Chemist
-  items:
-    - PillCanisterTricordrazine
-
-# Hyronalin
-- type: loadout
-  id: LoadoutMedicalRestrictedGearPillCanisterHyronalin
-  category: JobsMedicalChemist
-  cost: 2
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChemistEquipment
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Chemist
-  items:
-    - PillCanisterHyronalin
-
-# Bicaridine
-- type: loadout
-  id: LoadoutMedicalRestrictedGearPillCanisterBicaridine
-  category: JobsMedicalChemist
-  cost: 2
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChemistEquipment
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Chemist
-  items:
-    - PillCanisterBicaridine
-
-# Dermaline
-- type: loadout
-  id: LoadoutMedicalRestrictedGearPillCanisterDermaline
-  category: JobsMedicalChemist
-  cost: 2
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChemistEquipment
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Chemist
-  items:
-    - PillCanisterDermaline
-
-# Dylovene
-- type: loadout
-  id: LoadoutMedicalRestrictedGearPillCanisterDylovene
-  category: JobsMedicalChemist
-  cost: 2
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChemistEquipment
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Chemist
-  items:
-    - PillCanisterDylovene
-
-# Dexalin
-- type: loadout
-  id: LoadoutMedicalRestrictedGearPillCanisterDexalin
-  category: JobsMedicalChemist
-  cost: 1
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChemistEquipment
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Chemist
-  items:
-    - PillCanisterDexalin
-
-# LSD
-- type: loadout
-  id: LoadoutMedicalRestrictedGearPillCanisterSpaceDrugs
-  category: JobsMedicalChemist
-  cost: 1
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChemistEquipment
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Chemist
-  items:
-    - PillCanisterSpaceDrugs
-
-## Chemical Analysis Goggles
-- type: loadout
-  id: LoadoutMedicalRestrictedGearEyesGlassesChemical
-  category: JobsMedicalChemist
-  cost: 4
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Chemist
-  items:
-    - ClothingEyesGlassesChemical
-
-### Medical Doctor
-- type: loadout
-  id: LoadoutMedicalRestrictedGearBeltMedicalFilled
-  category: JobsMedicalMedicalDoctor
-  cost: 4
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - MedicalDoctor
-  items:
-    - ClothingBeltMedicalFilled
-
-
-### Paramedic
-- type: loadout
-  id: LoadoutMedicalRestrictedGearPortafib
-  category: JobsMedicalParamedic
-  cost: 3
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Paramedic
-  items:
-    - Portafib
+# WWDP edit start - trait removed
+#
+# ### All Medical
+#
+# ## Surgery
+# ## Note - Would it be more intuitive to move Surgery related items to Medical Doctor?
+# ## Also, individual surgical tools are also made available as it mightn't always viable to equip the surgical duffel bag
+# ## Getting the surgical duffel is cheaper than getting all the tools individually
+# ## However, Scalpel + Hemostat + Retractors + Cautery is only 4 points
+#
+# # Surgical Duffel
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearDuffelSurgeryFilled
+#   category: JobsMedicalAUncategorized
+#   cost: 5
+#   items:
+#     - ClothingBackpackDuffelSurgeryFilled
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Medical
+#
+# # Cautery
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearEquipmentCautery
+#   category: JobsMedicalAUncategorized
+#   cost: 1
+#   items:
+#     - Cautery
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Medical
+#
+# # Drill
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearEquipmentDrill
+#   category: JobsMedicalAUncategorized
+#   cost: 1
+#   items:
+#     - Drill
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Medical
+#
+# # Scalpel
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearEquipmentScalpel
+#   category: JobsMedicalAUncategorized
+#   cost: 1
+#   items:
+#     - Scalpel
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Medical
+#
+# # Retractor
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearEquipmentRetractor
+#   category: JobsMedicalAUncategorized
+#   cost: 1
+#   items:
+#     - Retractor
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Medical
+#
+# # Hemostat
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearEquipmentHemostat
+#   category: JobsMedicalAUncategorized
+#   cost: 1
+#   items:
+#     - Hemostat
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Medical
+#
+# # Bonesetter
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearEquipmentBonesetter
+#   category: JobsMedicalAUncategorized
+#   cost: 1
+#   items:
+#     - Bonesetter
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Medical
+#
+# # Bonegel
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearEquipmentBoneGel
+#   category: JobsMedicalAUncategorized
+#   cost: 1
+#   items:
+#     - BoneGel
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Medical
+#
+# # Metal Saw
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearEquipmentSaw
+#   category: JobsMedicalAUncategorized
+#   cost: 1
+#   items:
+#     - Saw
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Medical
+#
+#
+# ## Eyes
+# # Medhud
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearEyesHudMedical
+#   category: JobsMedicalAUncategorized
+#   cost: 2
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMedicalEyes
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Medical
+#   items:
+#     - ClothingEyesHudMedical
+#
+# # Eyepatch Medhud
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearEyepatchHudMedical
+#   category: JobsMedicalAUncategorized
+#   cost: 2
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMedicalEyes
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Medical
+#   items:
+#     - ClothingEyesEyepatchHudMedical
+#
+# # Medhud Prescription
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearHudMedicalPrescription
+#   category: JobsMedicalAUncategorized
+#   cost: 2
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#         - Nearsighted
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMedicalEyes
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Medical
+#   items:
+#     - ClothingEyesPrescriptionMedHud
+#
+# ## Gloves
+# # Nitrile
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearGlovesNitrile
+#   category: JobsMedicalAUncategorized
+#   cost: 1
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMedicalGloves
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Medical
+#   items:
+#     - ClothingHandsGlovesNitrile
+#
+# # Latex
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearGlovesLatex
+#   category: JobsMedicalAUncategorized
+#   cost: 1
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutMedicalGloves
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Medical
+#   items:
+#     - ClothingHandsGlovesLatex
+#
+# ## Stethoscope
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearNeckStethoscope
+#   category: JobsMedicalAUncategorized
+#   cost: 1
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Medical
+#   items:
+#     - ClothingNeckStethoscope
+#
+#
+# ### Chemist
+# ## Drugs
+# # Kelotane
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearPillCanisterKelotane
+#   category: JobsMedicalChemist
+#   cost: 2
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChemistEquipment
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - Chemist
+#   items:
+#     - PillCanisterKelotane
+#
+# # Tricordrazine
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearPillCanisterTricordrazine
+#   category: JobsMedicalChemist
+#   cost: 1
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChemistEquipment
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - Chemist
+#   items:
+#     - PillCanisterTricordrazine
+#
+# # Hyronalin
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearPillCanisterHyronalin
+#   category: JobsMedicalChemist
+#   cost: 2
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChemistEquipment
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - Chemist
+#   items:
+#     - PillCanisterHyronalin
+#
+# # Bicaridine
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearPillCanisterBicaridine
+#   category: JobsMedicalChemist
+#   cost: 2
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChemistEquipment
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - Chemist
+#   items:
+#     - PillCanisterBicaridine
+#
+# # Dermaline
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearPillCanisterDermaline
+#   category: JobsMedicalChemist
+#   cost: 2
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChemistEquipment
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - Chemist
+#   items:
+#     - PillCanisterDermaline
+#
+# # Dylovene
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearPillCanisterDylovene
+#   category: JobsMedicalChemist
+#   cost: 2
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChemistEquipment
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - Chemist
+#   items:
+#     - PillCanisterDylovene
+#
+# # Dexalin
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearPillCanisterDexalin
+#   category: JobsMedicalChemist
+#   cost: 1
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChemistEquipment
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - Chemist
+#   items:
+#     - PillCanisterDexalin
+#
+# # LSD
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearPillCanisterSpaceDrugs
+#   category: JobsMedicalChemist
+#   cost: 1
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutChemistEquipment
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - Chemist
+#   items:
+#     - PillCanisterSpaceDrugs
+#
+# ## Chemical Analysis Goggles
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearEyesGlassesChemical
+#   category: JobsMedicalChemist
+#   cost: 4
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - Chemist
+#   items:
+#     - ClothingEyesGlassesChemical
+#
+# ### Medical Doctor
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearBeltMedicalFilled
+#   category: JobsMedicalMedicalDoctor
+#   cost: 4
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - MedicalDoctor
+#   items:
+#     - ClothingBeltMedicalFilled
+#
+#
+# ### Paramedic
+# - type: loadout
+#   id: LoadoutMedicalRestrictedGearPortafib
+#   category: JobsMedicalParamedic
+#   cost: 3
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - Paramedic
+#   items:
+#     - Portafib
+#
+# WWDP edit end

--- a/Resources/Prototypes/Loadouts/Jobs/Security/corpsman.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/corpsman.yml
@@ -43,48 +43,53 @@
         - Brigmedic
 
 # Belt
-- type: loadout
-  id: LoadoutClothingBeltCorpsmanWebbing
-  category: JobsSecurityCorpsman
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutCorpsmanBelt
-    - !type:CharacterJobRequirement
-      jobs:
-        - Brigmedic
-  items:
-    - ClothingBeltCorpsmanWebbingFilled
+# WWDP edit start - moved to locker
+# - type: loadout
+#   id: LoadoutClothingBeltCorpsmanWebbing
+#   category: JobsSecurityCorpsman
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutCorpsmanBelt
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Brigmedic
+#   items:
+#     - ClothingBeltCorpsmanWebbingFilled
 
 # Ears
 
 # Equipment
-- type: loadout
-  id: LoadoutCrewMonitor
-  category: JobsSecurityCorpsman
-  cost: 6
-  requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - Brigmedic
-  items:
-    - HandheldCrewMonitor
+
+# - type: loadout
+#   id: LoadoutCrewMonitor
+#   category: JobsSecurityCorpsman
+#   cost: 6
+#   requirements:
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Brigmedic
+#   items:
+#     - HandheldCrewMonitor
 
 # Eyes
-- type: loadout
-  id: LoadoutClothingEyesGlassesCorpsman
-  category: JobsSecurityAUncategorized
-  cost: 2
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSecurityEyes
-    - !type:CharacterJobRequirement
-      jobs:
-        - Brigmedic
-  items:
-    - ClothingEyesGlassesCorpsman
+
+# - type: loadout
+#   id: LoadoutClothingEyesGlassesCorpsman
+#   category: JobsSecurityAUncategorized
+#   cost: 2
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSecurityEyes
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Brigmedic
+#   items:
+#     - ClothingEyesGlassesCorpsman
+#
+# WWDP edit end
 
 # Gloves
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/detective.yml
@@ -20,33 +20,36 @@
 # Mask
 
 # Outer
-- type: loadout
-  id: LoadoutClothingOuterCoatDetective
-  category: JobsSecurityDetective
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutDetectiveOuter
-    - !type:CharacterJobRequirement
-      jobs:
-        - Detective
-  items:
-    - ClothingOuterCoatDetective
 
-- type: loadout
-  id: LoadoutOuterVestDetective
-  category: JobsSecurityDetective
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutDetectiveOuter
-    - !type:CharacterJobRequirement
-      jobs:
-        - Detective
-  items:
-    - ClothingOuterVestDetective
+# WWDP edit start - moved to closet
+# - type: loadout
+#   id: LoadoutClothingOuterCoatDetective
+#   category: JobsSecurityDetective
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutDetectiveOuter
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Detective
+#   items:
+#     - ClothingOuterCoatDetective
+#
+# - type: loadout
+#   id: LoadoutOuterVestDetective
+#   category: JobsSecurityDetective
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutDetectiveOuter
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Detective
+#   items:
+#     - ClothingOuterVestDetective
+# WWDP edit end
 
 - type: loadout
   id: LoadoutClothingOuterJacketZavDetective

--- a/Resources/Prototypes/Loadouts/Jobs/Security/headOfSecurity.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/headOfSecurity.yml
@@ -40,37 +40,37 @@
 #   items:
 #     - WeaponPulsePistolHoS
 
-- type: loadout
-  id: LoadoutCommandHoSWt550
-  category: JobsSecurityHeadOfSecurity
-  cost: 0
-  canBeHeirloom: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutHeadOfSecurityWeapon
-    - !type:CharacterJobRequirement
-      jobs:
-        - HeadOfSecurity
-    - !type:CharacterAgeRequirement
-      min: 21
-  items:
-    - WeaponSubMachineGunWt550HoS
+# WWDP edit start - removed
+# - type: loadout
+#   id: LoadoutCommandHoSWt550
+#   category: JobsSecurityHeadOfSecurity
+#   cost: 0
+#   canBeHeirloom: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutHeadOfSecurityWeapon
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - HeadOfSecurity
+#     - !type:CharacterAgeRequirement
+#       min: 21
+#   items:
+#     - WeaponSubMachineGunWt550HoS
+#
+# - type: loadout
+#   id: LoadoutCommandHoSKatanaSheath
+#   category: JobsSecurityHeadOfSecurity
+#   cost: 0
+#   canBeHeirloom: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutHeadOfSecurityWeapon
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - HeadOfSecurity
+#   items:
+#     - ClothingBeltKatanaSheathFilledHoS
 
-- type: loadout
-  id: LoadoutCommandHoSKatanaSheath
-  category: JobsSecurityHeadOfSecurity
-  cost: 0
-  canBeHeirloom: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutHeadOfSecurityWeapon
-    - !type:CharacterJobRequirement
-      jobs:
-        - HeadOfSecurity
-  items:
-    - ClothingBeltKatanaSheathFilledHoS
-
-# WWDP no extra SEC guns
 # - type: loadout
 #   id: LoadoutCommandHoSC20r
 #   category: JobsSecurityHeadOfSecurity
@@ -117,23 +117,22 @@
 #   items:
 #     - EnergySwordHoS
 
-- type: loadout
-  id: LoadoutCommandHoSEnergyGun
-  category: JobsSecurityHeadOfSecurity
-  cost: 0
-  canBeHeirloom: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutHeadOfSecurityWeapon
-    - !type:CharacterJobRequirement
-      jobs:
-        - HeadOfSecurity
-    - !type:CharacterAgeRequirement
-      min: 21
-  items:
-    - WeaponEnergyGunMultiphase
+# - type: loadout
+#   id: LoadoutCommandHoSEnergyGun
+#   category: JobsSecurityHeadOfSecurity
+#   cost: 0
+#   canBeHeirloom: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutHeadOfSecurityWeapon
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - HeadOfSecurity
+#     - !type:CharacterAgeRequirement
+#       min: 21
+#   items:
+#     - WeaponEnergyGunMultiphase
 
-# WWDP no extra SEC guns
 # - type: loadout
 #   id: LoadoutCommandHoSBRDIR25
 #   category: JobsSecurityHeadOfSecurity
@@ -149,6 +148,7 @@
 #       min: 21
 #   items:
 #     - WeaponSubMachineGunBRDIR25HoS
+# WWDP edit end
 
 # Eyes
 
@@ -181,21 +181,22 @@
   items:
     - ClothingHeadHatHoshat
 
-- type: loadout
-  id: LoadoutCommandHOSHelmet
-  category: JobsSecurityHeadOfSecurity
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutHeadOfSecurityHead
-    - !type:CharacterJobRequirement
-      jobs:
-        - HeadOfSecurity
-  items:
-    - ClothingHeadHelmetHeavyHoS
-
+# WWDP edit start - disabled
+# - type: loadout
+#   id: LoadoutCommandHOSHelmet
+#   category: JobsSecurityHeadOfSecurity
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutHeadOfSecurityHead
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - HeadOfSecurity
+#   items:
+#     - ClothingHeadHelmetHeavyHoS
+#
 # Id
-# WWDP EDIT START - disabled
+#
 # - type: loadout
 #   id: LoadoutHeadOfSecurityNTPDA
 #   category: JobsSecurityHeadOfSecurity
@@ -273,44 +274,46 @@
   items:
   - ClothingOuterWinterHoSUnarmored
 
-- type: loadout
-  id: LoadoutCommandHOSOuterWinter
-  category: JobsSecurityHeadOfSecurity
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutHeadOfSecurityOuter
-    - !type:CharacterJobRequirement
-      jobs:
-        - HeadOfSecurity
-  items:
-    - ClothingOuterWinterHoS
-
-- type: loadout
-  id: LoadoutCommandHOSOuterTrench
-  category: JobsSecurityHeadOfSecurity
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutHeadOfSecurityOuter
-    - !type:CharacterJobRequirement
-      jobs:
-        - HeadOfSecurity
-  items:
-    - ClothingOuterCoatHoSTrench
-
-- type: loadout
-  id: LoadoutCommandHOSOuterHeavyArmor
-  category: JobsSecurityHeadOfSecurity
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutHeadOfSecurityOuter
-    - !type:CharacterJobRequirement
-      jobs:
-        - HeadOfSecurity
-  items:
-    - ClothingOuterArmorHoSHeavy
+# WWDP edit start - removed armor
+# - type: loadout
+#   id: LoadoutCommandHOSOuterWinter
+#   category: JobsSecurityHeadOfSecurity
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutHeadOfSecurityOuter
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - HeadOfSecurity
+#   items:
+#     - ClothingOuterWinterHoS
+#
+# - type: loadout
+#   id: LoadoutCommandHOSOuterTrench
+#   category: JobsSecurityHeadOfSecurity
+#   cost: 0
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutHeadOfSecurityOuter
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - HeadOfSecurity
+#   items:
+#     - ClothingOuterCoatHoSTrench
+#
+# - type: loadout
+#   id: LoadoutCommandHOSOuterHeavyArmor
+#   category: JobsSecurityHeadOfSecurity
+#   cost: 2
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutHeadOfSecurityOuter
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - HeadOfSecurity
+#   items:
+#     - ClothingOuterArmorHoSHeavy
+# WWDP edit end
 
 # Shoes
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Security/seniorOfficer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/seniorOfficer.yml
@@ -20,43 +20,44 @@
 # Ears
 
 # Equipment
-- type: loadout
-  id: LoadoutSecurityDisablerSMG
-  category: JobsSecuritySeniorOfficer
-  cost: 2
-  canBeHeirloom: true
-  guideEntry: SecurityWeapons
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityWeapons
-  - !type:CharacterJobRequirement
-    jobs:
-      - SeniorOfficer
-      - HeadOfSecurity
-      - BlueshieldOfficer
-  items:
-  - WeaponDisablerSMG
 
-- type: loadout
-  id: LoadoutSecurityPistolUniversal
-  category: JobsSecuritySeniorOfficer
-  cost: 6
-  canBeHeirloom: true
-  guideEntry: SecurityWeapons
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityWeapons
-  - !type:CharacterJobRequirement
-    jobs:
-    - SeniorOfficer
-    - HeadOfSecurity
-    - BlueshieldOfficer
-  - !type:CharacterAgeRequirement
-    min: 21
-  items:
-  - WeaponPistolUniversalSecurity
+# WWDP edit start - disabled
+# - type: loadout
+#   id: LoadoutSecurityDisablerSMG
+#   category: JobsSecuritySeniorOfficer
+#   cost: 2
+#   canBeHeirloom: true
+#   guideEntry: SecurityWeapons
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityWeapons
+#   - !type:CharacterJobRequirement
+#     jobs:
+#       - SeniorOfficer
+#       - HeadOfSecurity
+#       - BlueshieldOfficer
+#   items:
+#   - WeaponDisablerSMG
+#
+# - type: loadout
+#   id: LoadoutSecurityPistolUniversal
+#   category: JobsSecuritySeniorOfficer
+#   cost: 6
+#   canBeHeirloom: true
+#   guideEntry: SecurityWeapons
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityWeapons
+#   - !type:CharacterJobRequirement
+#     jobs:
+#     - SeniorOfficer
+#     - HeadOfSecurity
+#     - BlueshieldOfficer
+#   - !type:CharacterAgeRequirement
+#     min: 21
+#   items:
+#   - WeaponPistolUniversalSecurity
 
-# WD EDIT START
 # - type: loadout
 #   id: LoadoutSecurityPistolUniversalNonLethal
 #   category: JobsSecuritySeniorOfficer
@@ -75,47 +76,45 @@
 #     min: 21
 #   items:
 #   - WeaponPistolUniversalSecurityNonLethal
-# WD EDIT END
 
-- type: loadout
-  id: LoadoutMagazineUniversalMagnum
-  category: JobsSecuritySeniorOfficer
-  cost: 4
-  canBeHeirloom: true
-  guideEntry: SecurityWeapons
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityEquipment
-  - !type:CharacterJobRequirement
-    jobs:
-    - SeniorOfficer
-    - HeadOfSecurity
-    - BlueshieldOfficer
-  - !type:CharacterAgeRequirement
-    min: 21
-  items:
-  - MagazineUniversalMagnum
+# - type: loadout
+#   id: LoadoutMagazineUniversalMagnum
+#   category: JobsSecuritySeniorOfficer
+#   cost: 4
+#   canBeHeirloom: true
+#   guideEntry: SecurityWeapons
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityEquipment
+#   - !type:CharacterJobRequirement
+#     jobs:
+#     - SeniorOfficer
+#     - HeadOfSecurity
+#     - BlueshieldOfficer
+#   - !type:CharacterAgeRequirement
+#     min: 21
+#   items:
+#   - MagazineUniversalMagnum
+#
+# - type: loadout
+#   id: LoadoutMagazineUniversalMagnumSpare
+#   category: JobsSecuritySeniorOfficer
+#   cost: 4
+#   canBeHeirloom: true
+#   guideEntry: SecurityWeapons
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityEquipment
+#   - !type:CharacterJobRequirement
+#     jobs:
+#     - SeniorOfficer
+#     - HeadOfSecurity
+#     - BlueshieldOfficer
+#   - !type:CharacterAgeRequirement
+#     min: 21
+#   items:
+#   - MagazineUniversalMagnum
 
-- type: loadout
-  id: LoadoutMagazineUniversalMagnumSpare
-  category: JobsSecuritySeniorOfficer
-  cost: 4
-  canBeHeirloom: true
-  guideEntry: SecurityWeapons
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityEquipment
-  - !type:CharacterJobRequirement
-    jobs:
-    - SeniorOfficer
-    - HeadOfSecurity
-    - BlueshieldOfficer
-  - !type:CharacterAgeRequirement
-    min: 21
-  items:
-  - MagazineUniversalMagnum
-
-# WD EDIT START
 # - type: loadout
 #   id: LoadoutMagazineUniversalMagnumRubber
 #   category: JobsSecuritySeniorOfficer
@@ -153,7 +152,7 @@
 #     min: 21
 #   items:
 #   - MagazineUniversalMagnumRubber
-# WD EDIT END
+# WWDP EDIT END
 
 # Eyes
 

--- a/Resources/Prototypes/Loadouts/Jobs/Security/traitRestrictedGear.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/traitRestrictedGear.yml
@@ -1,90 +1,94 @@
-### All Security
-## Holster
-- type: loadout
-  id: LoadoutSecurityRestrictedGearBeltHolster
-  category: JobsSecurityAUncategorized
-  cost: 2
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Security
-  items:
-    - ClothingBeltHolster
-
-## Outer
-- type: loadout
-  id: LoadoutSecurityRestrictedGearOuterArmorPlateCarrier
-  category: JobsSecurityAUncategorized
-  cost: 7
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSecurityOuter
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Security
-  items:
-    - ClothingOuterArmorPlateCarrier
-
-- type: loadout
-  id: LoadoutSecurityRestrictedGearOuterArmorDuraVest
-  category: JobsSecurityAUncategorized
-  cost: 7
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSecurityOuter
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Security
-  items:
-    - ClothingOuterArmorDuraVest
-
-- type: loadout
-  id: LoadoutSecurityRestrictedGearOuterArmorBasic
-  category: JobsSecurityAUncategorized
-  cost: 7
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSecurityOuter
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Security
-  items:
-    - ClothingOuterArmorBasic
-
-- type: loadout
-  id: LoadoutSecurityRestrictedGearOuterArmorSlim
-  category: JobsSecurityAUncategorized
-  cost: 7
-  exclusive: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSecurityOuter
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-        - Security
-  items:
-    - ClothingOuterArmorBasicSlim
+# WWDP edit start - trait removed
+#
+# ### All Security
+# ## Holster
+# - type: loadout
+#   id: LoadoutSecurityRestrictedGearBeltHolster
+#   category: JobsSecurityAUncategorized
+#   cost: 2
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Security
+#   items:
+#     - ClothingBeltHolster
+#
+# ## Outer
+# - type: loadout
+#   id: LoadoutSecurityRestrictedGearOuterArmorPlateCarrier
+#   category: JobsSecurityAUncategorized
+#   cost: 7
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSecurityOuter
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Security
+#   items:
+#     - ClothingOuterArmorPlateCarrier
+#
+# - type: loadout
+#   id: LoadoutSecurityRestrictedGearOuterArmorDuraVest
+#   category: JobsSecurityAUncategorized
+#   cost: 7
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSecurityOuter
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Security
+#   items:
+#     - ClothingOuterArmorDuraVest
+#
+# - type: loadout
+#   id: LoadoutSecurityRestrictedGearOuterArmorBasic
+#   category: JobsSecurityAUncategorized
+#   cost: 7
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSecurityOuter
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Security
+#   items:
+#     - ClothingOuterArmorBasic
+#
+# - type: loadout
+#   id: LoadoutSecurityRestrictedGearOuterArmorSlim
+#   category: JobsSecurityAUncategorized
+#   cost: 7
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSecurityOuter
+#     - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#         - Security
+#   items:
+#     - ClothingOuterArmorBasicSlim
+#
+# WWDP edit end

--- a/Resources/Prototypes/Loadouts/Jobs/Security/uncategorized.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/uncategorized.yml
@@ -55,59 +55,62 @@
   - ClothingBackpackDuffelSecurity
 
 # Belt
-- type: loadout
-  id: LoadoutSecurityBeltWebbing
-  category: JobsSecurityAUncategorized
-  cost: 0
-  exclusive: true
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityBelt
-  - !type:CharacterDepartmentRequirement
-    departments:
-    - Security
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  items:
-  - ClothingBeltSecurityWebbingFilled
 
-- type: loadout
-  id: LoadoutClothingBeltSecurity
-  category: JobsSecurityAUncategorized
-  cost: 0
-  exclusive: true
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityBelt
-  - !type:CharacterDepartmentRequirement
-    departments:
-    - Security
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  items:
-  - ClothingBeltSecurityFilled
-
-- type: loadout
-  id: LoadoutClothingBeltHolster
-  category: JobsSecurityAUncategorized
-  cost: 0
-  exclusive: true
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityBelt
-  - !type:CharacterDepartmentRequirement
-    departments:
-    - Security
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  items:
-  - ClothingBeltHolster
+# WWDP edit start - disabled
+# - type: loadout
+#   id: LoadoutSecurityBeltWebbing
+#   category: JobsSecurityAUncategorized
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityBelt
+#   - !type:CharacterDepartmentRequirement
+#     departments:
+#     - Security
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   items:
+#   - ClothingBeltSecurityWebbingFilled
+#
+# - type: loadout
+#   id: LoadoutClothingBeltSecurity
+#   category: JobsSecurityAUncategorized
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityBelt
+#   - !type:CharacterDepartmentRequirement
+#     departments:
+#     - Security
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   items:
+#   - ClothingBeltSecurityFilled
+#
+# - type: loadout
+#   id: LoadoutClothingBeltHolster
+#   category: JobsSecurityAUncategorized
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityBelt
+#   - !type:CharacterDepartmentRequirement
+#     departments:
+#     - Security
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   items:
+#   - ClothingBeltHolster
+# WWDP edit end
 
 # Ears
 
@@ -263,23 +266,25 @@
 
 # Gloves
 
-- type: loadout
-  id: LoadoutSecurityCombatGloves
-  category: JobsSecurityAUncategorized
-  cost: 0
-  exclusive: true
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityGloves
-  - !type:CharacterDepartmentRequirement
-    departments:
-    - Security
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  items:
-  - ClothingHandsGlovesCombat
+# WWDP edit start - disabled
+# - type: loadout
+#   id: LoadoutSecurityCombatGloves
+#   category: JobsSecurityAUncategorized
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityGloves
+#   - !type:CharacterDepartmentRequirement
+#     departments:
+#     - Security
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   items:
+#   - ClothingHandsGlovesCombat
+# WWDP edit end
 
 # Head
 - type: loadout
@@ -300,40 +305,42 @@
   items:
   - ClothingHeadHatBeretSecurity
 
-- type: loadout
-  id: LoadoutClothingHeadHelmetBasic
-  category: JobsSecurityAUncategorized
-  cost: 0
-  exclusive: true
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityHead
-  - !type:CharacterDepartmentRequirement
-    departments:
-    - Security
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  items:
-  - ClothingHeadHelmetBasic
-
-- type: loadout
-  id: LoadoutSecurityHeadHelmetInsulated
-  category: JobsSecurityAUncategorized
-  cost: 1
-  guideEntry: PsionicInsulation
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityHead
-  # WD EDIT START
-  - !type:CharacterJobRequirement
-    jobs:
-    - Warden
-    - HeadOfSecurity
-    # WD EDIT END
-  items:
-  - ClothingHeadHelmetInsulated
+# WWDP edit start - disabled
+# - type: loadout
+#   id: LoadoutClothingHeadHelmetBasic
+#   category: JobsSecurityAUncategorized
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityHead
+#   - !type:CharacterDepartmentRequirement
+#     departments:
+#     - Security
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   items:
+#   - ClothingHeadHelmetBasic
+#
+# - type: loadout
+#   id: LoadoutSecurityHeadHelmetInsulated
+#   category: JobsSecurityAUncategorized
+#   cost: 1
+#   guideEntry: PsionicInsulation
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityHead
+#   # WD EDIT START
+#   - !type:CharacterJobRequirement
+#     jobs:
+#     - Warden
+#     - HeadOfSecurity
+#     # WD EDIT END
+#   items:
+#   - ClothingHeadHelmetInsulated
+# WWDP edit end
 
 # WD EDIT START
 # - type: loadout
@@ -435,39 +442,41 @@
 # Neck
 
 # Mask
-- type: loadout
-  id: LoadoutSecurityMaskGasSwat
-  category: JobsSecurityAUncategorized
-  cost: 0
-  exclusive: true
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityMask
-  - !type:CharacterJobRequirement
-    jobs:
-    - Warden
-    - HeadOfSecurity
-  items:
-  - ClothingMaskGasSwat
-
-
-- type: loadout
-  id: LoadoutSecurityMaskGasSwatPaid
-  category: JobsSecurityAUncategorized
-  cost: 4
-  exclusive: true
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityMask
-  - !type:CharacterJobRequirement
-    jobs:
-    - SecurityOfficer
-    - Detective
-    - Brigmedic
-    - PrisonGuard
-    - SecurityCadet
-  items:
-  - ClothingMaskGasSwat
+# WWDP edit start - disabled
+# - type: loadout
+#   id: LoadoutSecurityMaskGasSwat
+#   category: JobsSecurityAUncategorized
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityMask
+#   - !type:CharacterJobRequirement
+#     jobs:
+#     - Warden
+#     - HeadOfSecurity
+#   items:
+#   - ClothingMaskGasSwat
+#
+#
+# - type: loadout
+#   id: LoadoutSecurityMaskGasSwatPaid
+#   category: JobsSecurityAUncategorized
+#   cost: 4
+#   exclusive: true
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityMask
+#   - !type:CharacterJobRequirement
+#     jobs:
+#     - SecurityOfficer
+#     - Detective
+#     - Brigmedic
+#     - PrisonGuard
+#     - SecurityCadet
+#   items:
+#   - ClothingMaskGasSwat
+# WWDP edit end
 
 # Outer
 - type: loadout
@@ -487,80 +496,79 @@
   items:
   - ClothingOuterWinterSec
 
+# WWDP edit start - disabled
+# - type: loadout
+#   id: LoadoutClothingOuterArmorPlateCarrier
+#   category: JobsSecurityAUncategorized
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityOuter
+#   - !type:CharacterDepartmentRequirement
+#     departments:
+#     - Security
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   items:
+#   - ClothingOuterArmorPlateCarrier
+#
+# - type: loadout
+#   id: LoadoutClothingOuterArmorDuraVest
+#   category: JobsSecurityAUncategorized
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityOuter
+#   - !type:CharacterDepartmentRequirement
+#     departments:
+#     - Security
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   items:
+#   - ClothingOuterArmorDuraVest
+#
+# - type: loadout
+#   id: LoadoutClothingOuterArmorBasic
+#   category: JobsSecurityAUncategorized
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityOuter
+#   - !type:CharacterDepartmentRequirement
+#     departments:
+#     - Security
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   items:
+#   - ClothingOuterArmorBasic
+#
+# - type: loadout
+#   id: LoadoutClothingOuterArmorSlim
+#   category: JobsSecurityAUncategorized
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityOuter
+#   - !type:CharacterDepartmentRequirement
+#     departments:
+#     - Security
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   items:
+#   - ClothingOuterArmorBasicSlim
 
-- type: loadout
-  id: LoadoutClothingOuterArmorPlateCarrier
-  category: JobsSecurityAUncategorized
-  cost: 0
-  exclusive: true
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityOuter
-  - !type:CharacterDepartmentRequirement
-    departments:
-    - Security
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  items:
-  - ClothingOuterArmorPlateCarrier
-
-- type: loadout
-  id: LoadoutClothingOuterArmorDuraVest
-  category: JobsSecurityAUncategorized
-  cost: 0
-  exclusive: true
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityOuter
-  - !type:CharacterDepartmentRequirement
-    departments:
-    - Security
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  items:
-  - ClothingOuterArmorDuraVest
-
-- type: loadout
-  id: LoadoutClothingOuterArmorBasic
-  category: JobsSecurityAUncategorized
-  cost: 0
-  exclusive: true
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityOuter
-  - !type:CharacterDepartmentRequirement
-    departments:
-    - Security
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  items:
-  - ClothingOuterArmorBasic
-
-- type: loadout
-  id: LoadoutClothingOuterArmorSlim
-  category: JobsSecurityAUncategorized
-  cost: 0
-  exclusive: true
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityOuter
-  - !type:CharacterDepartmentRequirement
-    departments:
-    - Security
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  items:
-  - ClothingOuterArmorBasicSlim
-
-# WD EDIT START
 # - type: loadout
 #   id: ClothingOuterArmorTCFLHeavy
 #   category: JobsSecurityAUncategorized
@@ -628,7 +636,7 @@
 #     - Prisoner
 #   items:
 #   - ClothingOuterArmorStandardHeavy
-# WD EDIT END
+# WWDP EDIT END
 
 - type: loadout
   id: LoadoutClothingOuterJacketZavSecurity
@@ -675,41 +683,43 @@
   - ClothingOuterJacketZavSecurityAlt
 
 # Shoes
-- type: loadout
-  id: LoadoutSecurityShoesJackboots
-  category: JobsSecurityAUncategorized
-  cost: 0
-  exclusive: true
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityShoes
-  - !type:CharacterDepartmentRequirement
-    departments:
-    - Security
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  items:
-  - ClothingShoesBootsJack
-
-- type: loadout
-  id: LoadoutClothingShoesBootsCombat
-  category: JobsSecurityAUncategorized
-  cost: 0
-  exclusive: true
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityShoes
-  - !type:CharacterDepartmentRequirement
-    departments:
-    - Security
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  items:
-  - ClothingShoesBootsCombatFilled
+# WWDP edit start - disabled
+# - type: loadout
+#   id: LoadoutSecurityShoesJackboots
+#   category: JobsSecurityAUncategorized
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityShoes
+#   - !type:CharacterDepartmentRequirement
+#     departments:
+#     - Security
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   items:
+#   - ClothingShoesBootsJack
+#
+# - type: loadout
+#   id: LoadoutClothingShoesBootsCombat
+#   category: JobsSecurityAUncategorized
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityShoes
+#   - !type:CharacterDepartmentRequirement
+#     departments:
+#     - Security
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   items:
+#   - ClothingShoesBootsCombatFilled
+# WWDP edit end
 
 # Uniforms
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/warden.yml
@@ -33,32 +33,35 @@
 # Mask
 
 # Outer
-- type: loadout
-  id: LoadoutClothingOuterWinterCoatWarden
-  category: JobsSecurityWarden
-  cost: 0
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutWardenOuter
-  - !type:CharacterJobRequirement
-    jobs:
-      - Warden
-  items:
-  - ClothingOuterWinterWardenUnarmored
 
-- type: loadout
-  id: LoadoutClothingOuterCoatWarden
-  category: JobsSecurityWarden
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutWardenOuter
-    - !type:CharacterJobRequirement
-      jobs:
-        - Warden
-  items:
-    - ClothingOuterCoatWarden
+# WWDP edit start - moved to locker
+# - type: loadout
+#   id: LoadoutClothingOuterWinterCoatWarden
+#   category: JobsSecurityWarden
+#   cost: 0
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutWardenOuter
+#   - !type:CharacterJobRequirement
+#     jobs:
+#       - Warden
+#   items:
+#   - ClothingOuterWinterWardenUnarmored
+#
+# - type: loadout
+#   id: LoadoutClothingOuterCoatWarden
+#   category: JobsSecurityWarden
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutWardenOuter
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Warden
+#   items:
+#     - ClothingOuterCoatWarden
+# WWDP edit end
 
 # Shoes
 

--- a/Resources/Prototypes/Loadouts/Jobs/Security/weapons.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/weapons.yml
@@ -9,105 +9,106 @@
 # Equipment, limit 3 selections
 # Duplicate "Spare" equipment exists and shares the ItemGroup, for those officers who like to pack a spare magazine in their pocket, outside of what was issued to them.
 # I knew a lot of people in my time working IRL Armed security that did this.
-- type: loadout
-  id: LoadoutSecurityCombatKnife
-  category: JobsSecurityWeapons
-  cost: 0
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityEquipment
-  - !type:CharacterLogicOrRequirement
-    requirements:
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Security
-    - !type:CharacterJobRequirement
-      jobs:
-      - BlueshieldOfficer
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  items:
-  - CombatKnife
 
-- type: loadout
-  id: LoadoutSecurityFlash
-  category: JobsSecurityWeapons
-  cost: 0
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityEquipment
-  - !type:CharacterLogicOrRequirement
-    requirements:
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Security
-    - !type:CharacterJobRequirement
-      jobs:
-      - BlueshieldOfficer
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  items:
-  - Flash
+# WWDP giga edit start - all options disabled
+# - type: loadout
+#   id: LoadoutSecurityCombatKnife
+#   category: JobsSecurityWeapons
+#   cost: 0
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityEquipment
+#   - !type:CharacterLogicOrRequirement
+#     requirements:
+#     - !type:CharacterDepartmentRequirement
+#       departments:
+#       - Security
+#     - !type:CharacterJobRequirement
+#       jobs:
+#       - BlueshieldOfficer
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   items:
+#   - CombatKnife
+#
+# - type: loadout
+#   id: LoadoutSecurityFlash
+#   category: JobsSecurityWeapons
+#   cost: 0
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityEquipment
+#   - !type:CharacterLogicOrRequirement
+#     requirements:
+#     - !type:CharacterDepartmentRequirement
+#       departments:
+#       - Security
+#     - !type:CharacterJobRequirement
+#       jobs:
+#       - BlueshieldOfficer
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   items:
+#   - Flash
+#
+# - type: loadout
+#   id: LoadoutMagazinePistol
+#   category: JobsSecurityWeapons
+#   cost: 0
+#   requirements:
+#   - !type:CharacterDepartmentTimeRequirement
+#     department: Security
+#     min: 3600 # 1 hours
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityEquipment
+#   - !type:CharacterLogicOrRequirement
+#     requirements:
+#     - !type:CharacterDepartmentRequirement
+#       departments:
+#       - Security
+#     - !type:CharacterJobRequirement
+#       jobs:
+#       - BlueshieldOfficer
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   - !type:CharacterAgeRequirement
+#     min: 21
+#   items:
+#   - MagazinePistol
+#
+# - type: loadout
+#   id: LoadoutMagazinePistolSpare
+#   category: JobsSecurityWeapons
+#   cost: 2
+#   requirements:
+#   - !type:CharacterDepartmentTimeRequirement
+#     department: Security
+#     min: 3600 # 1 hours
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityEquipment
+#   - !type:CharacterLogicOrRequirement
+#     requirements:
+#     - !type:CharacterDepartmentRequirement
+#       departments:
+#       - Security
+#     - !type:CharacterJobRequirement
+#       jobs:
+#       - BlueshieldOfficer
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   - !type:CharacterAgeRequirement
+#     min: 21
+#   items:
+#   - MagazinePistol
 
-- type: loadout
-  id: LoadoutMagazinePistol
-  category: JobsSecurityWeapons
-  cost: 0
-  requirements:
-  - !type:CharacterDepartmentTimeRequirement
-    department: Security
-    min: 3600 # 1 hours
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityEquipment
-  - !type:CharacterLogicOrRequirement
-    requirements:
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Security
-    - !type:CharacterJobRequirement
-      jobs:
-      - BlueshieldOfficer
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  - !type:CharacterAgeRequirement
-    min: 21
-  items:
-  - MagazinePistol
-
-- type: loadout
-  id: LoadoutMagazinePistolSpare
-  category: JobsSecurityWeapons
-  cost: 2
-  requirements:
-  - !type:CharacterDepartmentTimeRequirement
-    department: Security
-    min: 3600 # 1 hours
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityEquipment
-  - !type:CharacterLogicOrRequirement
-    requirements:
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Security
-    - !type:CharacterJobRequirement
-      jobs:
-      - BlueshieldOfficer
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  - !type:CharacterAgeRequirement
-    min: 21
-  items:
-  - MagazinePistol
-
-# WD EDIT START
 # - type: loadout
 #   id: LoadoutMagazinePistolRubber
 #   category: JobsSecurityWeapons
@@ -155,65 +156,63 @@
 #     min: 21
 #   items:
 #   - MagazinePistolRubber
-# WD EDIT END
 
-- type: loadout
-  id: LoadoutSpeedLoaderMagnum
-  category: JobsSecurityWeapons
-  cost: 2
-  exclusive: true
-  requirements:
-  - !type:CharacterDepartmentTimeRequirement
-    department: Security
-    min: 3600 # 1 hours
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityEquipment
-  - !type:CharacterLogicOrRequirement
-    requirements:
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Security
-    - !type:CharacterJobRequirement
-      jobs:
-      - BlueshieldOfficer
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  - !type:CharacterAgeRequirement
-    min: 21
-  items:
-  - SpeedLoaderMagnum
+# - type: loadout
+#   id: LoadoutSpeedLoaderMagnum
+#   category: JobsSecurityWeapons
+#   cost: 2
+#   exclusive: true
+#   requirements:
+#   - !type:CharacterDepartmentTimeRequirement
+#     department: Security
+#     min: 3600 # 1 hours
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityEquipment
+#   - !type:CharacterLogicOrRequirement
+#     requirements:
+#     - !type:CharacterDepartmentRequirement
+#       departments:
+#       - Security
+#     - !type:CharacterJobRequirement
+#       jobs:
+#       - BlueshieldOfficer
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   - !type:CharacterAgeRequirement
+#     min: 21
+#   items:
+#   - SpeedLoaderMagnum
+#
+# - type: loadout
+#   id: LoadoutSpeedLoaderMagnumSpare
+#   category: JobsSecurityWeapons
+#   cost: 4
+#   exclusive: true
+#   requirements:
+#   - !type:CharacterDepartmentTimeRequirement
+#     department: Security
+#     min: 3600 # 1 hours
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityEquipment
+#   - !type:CharacterLogicOrRequirement
+#     requirements:
+#     - !type:CharacterDepartmentRequirement
+#       departments:
+#       - Security
+#     - !type:CharacterJobRequirement
+#       jobs:
+#       - BlueshieldOfficer
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   - !type:CharacterAgeRequirement
+#     min: 21
+#   items:
+#   - SpeedLoaderMagnum
 
-- type: loadout
-  id: LoadoutSpeedLoaderMagnumSpare
-  category: JobsSecurityWeapons
-  cost: 4
-  exclusive: true
-  requirements:
-  - !type:CharacterDepartmentTimeRequirement
-    department: Security
-    min: 3600 # 1 hours
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityEquipment
-  - !type:CharacterLogicOrRequirement
-    requirements:
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Security
-    - !type:CharacterJobRequirement
-      jobs:
-      - BlueshieldOfficer
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  - !type:CharacterAgeRequirement
-    min: 21
-  items:
-  - SpeedLoaderMagnum
-
-# WD EDIT START
 # - type: loadout
 #   id: LoadoutSpeedLoaderMagnumRubber
 #   category: JobsSecurityWeapons
@@ -263,37 +262,35 @@
 #     min: 21
 #   items:
 #   - SpeedLoaderMagnumRubber
-# WD EDIT END
 
-- type: loadout
-  id: LoadoutMagazineMagnum
-  category: JobsSecurityWeapons
-  cost: 4
-  exclusive: true
-  requirements:
-  - !type:CharacterDepartmentTimeRequirement
-    department: Security
-    min: 3600 # 1 hours
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityEquipment
-  - !type:CharacterLogicOrRequirement
-    requirements:
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Security
-    - !type:CharacterJobRequirement
-      jobs:
-      - BlueshieldOfficer
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  - !type:CharacterAgeRequirement
-    min: 21
-  items:
-  - MagazineMagnum
+# - type: loadout
+#   id: LoadoutMagazineMagnum
+#   category: JobsSecurityWeapons
+#   cost: 4
+#   exclusive: true
+#   requirements:
+#   - !type:CharacterDepartmentTimeRequirement
+#     department: Security
+#     min: 3600 # 1 hours
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityEquipment
+#   - !type:CharacterLogicOrRequirement
+#     requirements:
+#     - !type:CharacterDepartmentRequirement
+#       departments:
+#       - Security
+#     - !type:CharacterJobRequirement
+#       jobs:
+#       - BlueshieldOfficer
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   - !type:CharacterAgeRequirement
+#     min: 21
+#   items:
+#   - MagazineMagnum
 
-# WD EDIT START
 # - type: loadout
 #   id: LoadoutMagazineMagnumRubber
 #   category: JobsSecurityWeapons
@@ -321,37 +318,35 @@
 #     min: 21
 #   items:
 #   - MagazineMagnumRubber
-# WD EDIT END
 
-- type: loadout
-  id: LoadoutMagazineMagnumSpare
-  category: JobsSecurityWeapons
-  cost: 4
-  exclusive: true
-  requirements:
-  - !type:CharacterDepartmentTimeRequirement
-    department: Security
-    min: 3600 # 1 hours
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityEquipment
-  - !type:CharacterLogicOrRequirement
-    requirements:
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Security
-    - !type:CharacterJobRequirement
-      jobs:
-      - BlueshieldOfficer
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  - !type:CharacterAgeRequirement
-    min: 21
-  items:
-  - MagazineMagnum
+# - type: loadout
+#   id: LoadoutMagazineMagnumSpare
+#   category: JobsSecurityWeapons
+#   cost: 4
+#   exclusive: true
+#   requirements:
+#   - !type:CharacterDepartmentTimeRequirement
+#     department: Security
+#     min: 3600 # 1 hours
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityEquipment
+#   - !type:CharacterLogicOrRequirement
+#     requirements:
+#     - !type:CharacterDepartmentRequirement
+#       departments:
+#       - Security
+#     - !type:CharacterJobRequirement
+#       jobs:
+#       - BlueshieldOfficer
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   - !type:CharacterAgeRequirement
+#     min: 21
+#   items:
+#   - MagazineMagnum
 
-# WD EDIT START
 # - type: loadout
 #   id: LoadoutMagazineMagnumRubberSpare
 #   category: JobsSecurityWeapons
@@ -485,66 +480,64 @@
 #     min: 21
 #   items:
 #   - SpeedLoaderRifleHeavyRubber
-# WD EDIT END
 
 # Service Weapon, limit 1 selection.
 # Security no longer spawns with a weapon automatically, instead they have a free choice of security appropriate Duty Pistol in their loadouts.
 # This category is universal to the entire security department by special request, so that players can choose their preferred Duty Pistol even if they aren't playing a security role.
 # All lethal options come with a 1 hour security department playtime, as a basic shitter protection.
-- type: loadout
-  id: LoadoutSecurityDisabler
-  category: JobsSecurityWeapons
-  cost: 0
-  canBeHeirloom: true
-  guideEntry: SecurityWeapons
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityWeapons
-  - !type:CharacterLogicOrRequirement
-    requirements:
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Security
-    - !type:CharacterJobRequirement
-      jobs:
-      - BlueshieldOfficer
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  items:
-  - WeaponDisabler
+# - type: loadout
+#   id: LoadoutSecurityDisabler
+#   category: JobsSecurityWeapons
+#   cost: 0
+#   canBeHeirloom: true
+#   guideEntry: SecurityWeapons
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityWeapons
+#   - !type:CharacterLogicOrRequirement
+#     requirements:
+#     - !type:CharacterDepartmentRequirement
+#       departments:
+#       - Security
+#     - !type:CharacterJobRequirement
+#       jobs:
+#       - BlueshieldOfficer
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   items:
+#   - WeaponDisabler
+#
+# - type: loadout
+#   id: LoadoutSecurityMk58
+#   category: JobsSecurityWeapons
+#   cost: 0
+#   canBeHeirloom: true
+#   guideEntry: SecurityWeapons
+#   requirements:
+#   - !type:CharacterDepartmentTimeRequirement
+#     department: Security
+#     min: 3600 # 1 hours
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityWeapons
+#   - !type:CharacterLogicOrRequirement
+#     requirements:
+#     - !type:CharacterDepartmentRequirement
+#       departments:
+#       - Security
+#     - !type:CharacterJobRequirement
+#       jobs:
+#       - BlueshieldOfficer
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   - !type:CharacterAgeRequirement
+#     min: 21
+#   items:
+#   - WeaponPistolMk58Security
 
-- type: loadout
-  id: LoadoutSecurityMk58
-  category: JobsSecurityWeapons
-  cost: 0
-  canBeHeirloom: true
-  guideEntry: SecurityWeapons
-  requirements:
-  - !type:CharacterDepartmentTimeRequirement
-    department: Security
-    min: 3600 # 1 hours
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityWeapons
-  - !type:CharacterLogicOrRequirement
-    requirements:
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Security
-    - !type:CharacterJobRequirement
-      jobs:
-      - BlueshieldOfficer
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  - !type:CharacterAgeRequirement
-    min: 21
-  items:
-  - WeaponPistolMk58Security
-
-# WD EDIT START
 # - type: loadout
 #   id: LoadoutSecurityMk58NonLethal
 #   category: JobsSecurityWeapons
@@ -570,38 +563,36 @@
 #     min: 21
 #   items:
 #   - WeaponPistolMk58SecurityNonlethal
-# WD EDIT END
 
-- type: loadout
-  id: LoadoutSecurityRevolver
-  category: JobsSecurityWeapons
-  cost: 0
-  canBeHeirloom: true
-  guideEntry: SecurityWeapons
-  requirements:
-  - !type:CharacterDepartmentTimeRequirement
-    department: Security
-    min: 3600 # 1 hours
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityWeapons
-  - !type:CharacterLogicOrRequirement
-    requirements:
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Security
-    - !type:CharacterJobRequirement
-      jobs:
-      - BlueshieldOfficer
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  - !type:CharacterAgeRequirement
-    min: 21
-  items:
-  - WeaponRevolverInspectorSecurity
+# - type: loadout
+#   id: LoadoutSecurityRevolver
+#   category: JobsSecurityWeapons
+#   cost: 0
+#   canBeHeirloom: true
+#   guideEntry: SecurityWeapons
+#   requirements:
+#   - !type:CharacterDepartmentTimeRequirement
+#     department: Security
+#     min: 3600 # 1 hours
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityWeapons
+#   - !type:CharacterLogicOrRequirement
+#     requirements:
+#     - !type:CharacterDepartmentRequirement
+#       departments:
+#       - Security
+#     - !type:CharacterJobRequirement
+#       jobs:
+#       - BlueshieldOfficer
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   - !type:CharacterAgeRequirement
+#     min: 21
+#   items:
+#   - WeaponRevolverInspectorSecurity
 
-# WD EDIT START
 # - type: loadout
 #   id: LoadoutSecurityRevolverNonLethal
 #   category: JobsSecurityWeapons
@@ -682,38 +673,36 @@
 #     min: 21
 #   items:
 #   - WeaponRevolverDeckardNonLethalSecurity
-# WD EDIT END
 
-- type: loadout
-  id: LoadoutSecurityPistolN1984
-  category: JobsSecurityWeapons
-  cost: 5
-  canBeHeirloom: true
-  guideEntry: SecurityWeapons
-  requirements:
-  - !type:CharacterDepartmentTimeRequirement
-    department: Security
-    min: 3600 # 1 hours
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityWeapons
-  - !type:CharacterLogicOrRequirement
-    requirements:
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Security
-    - !type:CharacterJobRequirement
-      jobs:
-      - BlueshieldOfficer
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  - !type:CharacterAgeRequirement
-    min: 21
-  items:
-  - WeaponPistolN1984Security
+# - type: loadout
+#   id: LoadoutSecurityPistolN1984
+#   category: JobsSecurityWeapons
+#   cost: 5
+#   canBeHeirloom: true
+#   guideEntry: SecurityWeapons
+#   requirements:
+#   - !type:CharacterDepartmentTimeRequirement
+#     department: Security
+#     min: 3600 # 1 hours
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityWeapons
+#   - !type:CharacterLogicOrRequirement
+#     requirements:
+#     - !type:CharacterDepartmentRequirement
+#       departments:
+#       - Security
+#     - !type:CharacterJobRequirement
+#       jobs:
+#       - BlueshieldOfficer
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   - !type:CharacterAgeRequirement
+#     min: 21
+#   items:
+#   - WeaponPistolN1984Security
 
-# WD EDIT START
 # - type: loadout
 #   id: LoadoutSecurityPistolN1984NonLethal
 #   category: JobsSecurityWeapons
@@ -823,39 +812,37 @@
 #     min: 21
 #   items:
 #   - WeaponPistolViperWoodSecurity
-# WD EDIT END
 
-- type: loadout
-  id: LoadoutSecurityEquipmentTruncheon
-  category: JobsSecurityWeapons
-  cost: 3
-  canBeHeirloom: true
-  guideEntry: SecurityWeapons
-  requirements:
-  - !type:CharacterDepartmentTimeRequirement
-    department: Security
-    min: 3600 # 1 hours
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityWeapons
-  - !type:CharacterLogicOrRequirement
-    requirements:
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Security
-    - !type:CharacterJobRequirement
-      jobs:
-      - BlueshieldOfficer
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  - !type:CharacterSpeciesRequirement
-    species:
-    - Oni
-  items:
-  - Truncheon
+# - type: loadout
+#   id: LoadoutSecurityEquipmentTruncheon
+#   category: JobsSecurityWeapons
+#   cost: 3
+#   canBeHeirloom: true
+#   guideEntry: SecurityWeapons
+#   requirements:
+#   - !type:CharacterDepartmentTimeRequirement
+#     department: Security
+#     min: 3600 # 1 hours
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityWeapons
+#   - !type:CharacterLogicOrRequirement
+#     requirements:
+#     - !type:CharacterDepartmentRequirement
+#       departments:
+#       - Security
+#     - !type:CharacterJobRequirement
+#       jobs:
+#       - BlueshieldOfficer
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   - !type:CharacterSpeciesRequirement
+#     species:
+#     - Oni
+#   items:
+#   - Truncheon
 
-# WD EDIT START
 # - type: loadout
 #   id: LoadoutSecurityEquipmentEnergySword
 #   category: JobsSecurityWeapons
@@ -911,67 +898,65 @@
 #     min: 21
 #   items:
 #  - WeaponLaserSvalinn
-# WD EDIT END
 
-- type: loadout
-  id: LoadoutSecurityEnergyGunMini
-  category: JobsSecurityWeapons
-  cost: 2
-  canBeHeirloom: true
-  guideEntry: SecurityWeapons
-  requirements:
-  - !type:CharacterDepartmentTimeRequirement
-    department: Security
-    min: 3600 # 1 hours
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityWeapons
-  - !type:CharacterLogicOrRequirement
-    requirements:
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Security
-    - !type:CharacterJobRequirement
-      jobs:
-      - BlueshieldOfficer
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  - !type:CharacterAgeRequirement
-    min: 21
-  items:
-  - WeaponEnergyGunMiniSecurity
-
-- type: loadout
-  id: LoadoutSecurityEnergyGunPistol
-  category: JobsSecurityWeapons
-  cost: 2
-  canBeHeirloom: true
-  guideEntry: SecurityWeapons
-  requirements:
-  - !type:CharacterDepartmentTimeRequirement
-    department: Security
-    min: 3600 # 1 hours
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityWeapons
-  - !type:CharacterLogicOrRequirement
-    requirements:
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Security
-    - !type:CharacterJobRequirement
-      jobs:
-      - BlueshieldOfficer
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  - !type:CharacterAgeRequirement
-    min: 21
-  items:
-  - WeaponEnergyGunPistolSecurity
-
-# WD EDIT START
+# - type: loadout
+#   id: LoadoutSecurityEnergyGunMini
+#   category: JobsSecurityWeapons
+#   cost: 2
+#   canBeHeirloom: true
+#   guideEntry: SecurityWeapons
+#   requirements:
+#   - !type:CharacterDepartmentTimeRequirement
+#     department: Security
+#     min: 3600 # 1 hours
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityWeapons
+#   - !type:CharacterLogicOrRequirement
+#     requirements:
+#     - !type:CharacterDepartmentRequirement
+#       departments:
+#       - Security
+#     - !type:CharacterJobRequirement
+#       jobs:
+#       - BlueshieldOfficer
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   - !type:CharacterAgeRequirement
+#     min: 21
+#   items:
+#   - WeaponEnergyGunMiniSecurity
+#
+# - type: loadout
+#   id: LoadoutSecurityEnergyGunPistol
+#   category: JobsSecurityWeapons
+#   cost: 2
+#   canBeHeirloom: true
+#   guideEntry: SecurityWeapons
+#   requirements:
+#   - !type:CharacterDepartmentTimeRequirement
+#     department: Security
+#     min: 3600 # 1 hours
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityWeapons
+#   - !type:CharacterLogicOrRequirement
+#     requirements:
+#     - !type:CharacterDepartmentRequirement
+#       departments:
+#       - Security
+#     - !type:CharacterJobRequirement
+#       jobs:
+#       - BlueshieldOfficer
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   - !type:CharacterAgeRequirement
+#     min: 21
+#   items:
+#   - WeaponEnergyGunPistolSecurity
+#
 # - type: loadout
 #   id: LoadoutSecurityPistolPollock
 #   category: JobsSecurityWeapons
@@ -1026,7 +1011,6 @@
 #     min: 21
 #   items:
 #   - WeaponPistolPollockNonlethalSecurity
-# WD EDIT END
 
 # - type: loadout
 #   id: LoadoutSecurityRevolverSnub
@@ -1331,35 +1315,35 @@
 #     min: 21
 #   items:
 #   - WeaponEnergyRevolverSecurity
-# WD EDIT END
 
-- type: loadout
-  id: LoadoutSecurityShotgunSawnLumen
-  category: JobsSecurityWeapons
-  cost: 0
-  canBeHeirloom: true
-  guideEntry: SecurityWeapons
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutSecurityWeapons
-  - !type:CharacterLogicOrRequirement
-    requirements:
-    - !type:CharacterDepartmentRequirement
-      departments:
-      - Security
-    - !type:CharacterJobRequirement
-      jobs:
-      - BlueshieldOfficer
-  - !type:CharacterJobRequirement # WWDP
-    inverted: true
-    jobs:
-    - Prisoner
-  - !type:CharacterAgeRequirement
-    min: 21
-  items:
-  - WeaponShotgunSawnLumen
-  - ShellShotgunLumen
-  - ShellShotgunLumen
+# - type: loadout
+#   id: LoadoutSecurityShotgunSawnLumen
+#   category: JobsSecurityWeapons
+#   cost: 0
+#   canBeHeirloom: true
+#   guideEntry: SecurityWeapons
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutSecurityWeapons
+#   - !type:CharacterLogicOrRequirement
+#     requirements:
+#     - !type:CharacterDepartmentRequirement
+#       departments:
+#       - Security
+#     - !type:CharacterJobRequirement
+#       jobs:
+#       - BlueshieldOfficer
+#   - !type:CharacterJobRequirement # WWDP
+#     inverted: true
+#     jobs:
+#     - Prisoner
+#   - !type:CharacterAgeRequirement
+#     min: 21
+#   items:
+#   - WeaponShotgunSawnLumen
+#   - ShellShotgunLumen
+#   - ShellShotgunLumen
+# WWDP giga edit end
 
 # Eyes
 

--- a/Resources/Prototypes/Loadouts/Jobs/Service/bartender.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Service/bartender.yml
@@ -6,133 +6,136 @@
 # Ears
 
 # Equipment
-- type: loadout
-  id: LoadoutServiceBartenderBoxBeanbags
-  category: JobsServiceBartender
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBartenderAmmo
-    - !type:CharacterJobRequirement
-      jobs:
-        - Bartender
-    - !type:CharacterAgeRequirement
-      min: 21
-  items:
-    - BoxBeanbag
 
-- type: loadout
-  id: LoadoutServiceBartenderBoxLightRifle
-  category: JobsServiceBartender
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBartenderAmmo
-    - !type:CharacterJobRequirement
-      jobs:
-        - Bartender
-    - !type:CharacterAgeRequirement
-      min: 21
-  items:
-    - MagazineBoxLightRifle
-
-- type: loadout
-  id: LoadoutServiceBartenderBoxRifle
-  category: JobsServiceBartender
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBartenderAmmo
-    - !type:CharacterJobRequirement
-      jobs:
-        - Bartender
-    - !type:CharacterAgeRequirement
-      min: 21
-  items:
-    - MagazineBoxRifle
-
-- type: loadout
-  id: LoadoutServiceBartenderShotgunDoubleBarreled
-  category: JobsServiceBartender
-  cost: 0
-  canBeHeirloom: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBartenderWeapon
-    - !type:CharacterJobRequirement
-      jobs:
-        - Bartender
-    - !type:CharacterAgeRequirement
-      min: 21
-  items:
-    - WeaponShotgunDoubleBarreledRubber # WWDP
-
-- type: loadout
-  id: LoadoutServiceBartenderMosin
-  category: JobsServiceBartender
-  cost: 0
-  canBeHeirloom: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBartenderWeapon
-    - !type:CharacterJobRequirement
-      jobs:
-        - Bartender
-    - !type:CharacterAgeRequirement
-      min: 21
-  items:
-    - WeaponSniperMosin
-
-- type: loadout
-  id: LoadoutServiceBartenderBoxMagnum
-  category: JobsServiceBartender
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBartenderAmmo
-    - !type:CharacterJobRequirement
-      jobs:
-        - Bartender
-    - !type:CharacterAgeRequirement
-      min: 21
-  items:
-    - MagazineBoxMagnum
-
-- type: loadout
-  id: LoadoutServiceBartenderArgenti
-  category: JobsServiceBartender
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBartenderWeapon
-    - !type:CharacterJobRequirement
-      jobs:
-        - Bartender
-    - !type:CharacterAgeRequirement
-      min: 21
-  items:
-    - WeaponRevolverArgenti
-
-- type: loadout
-  id: LoadoutServiceBartenderRepeater
-  category: JobsServiceBartender
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBartenderWeapon
-    - !type:CharacterJobRequirement
-      jobs:
-        - Bartender
-    - !type:CharacterAgeRequirement
-      min: 21
-  items:
-    - WeaponSniperRepeater
+# WWDP edit start - removed loadouts, back to closet
+# - type: loadout
+#   id: LoadoutServiceBartenderBoxBeanbags
+#   category: JobsServiceBartender
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBartenderAmmo
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Bartender
+#     - !type:CharacterAgeRequirement
+#       min: 21
+#   items:
+#     - BoxBeanbag
+#
+# - type: loadout
+#   id: LoadoutServiceBartenderBoxLightRifle
+#   category: JobsServiceBartender
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBartenderAmmo
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Bartender
+#     - !type:CharacterAgeRequirement
+#       min: 21
+#   items:
+#     - MagazineBoxLightRifle
+#
+# - type: loadout
+#   id: LoadoutServiceBartenderBoxRifle
+#   category: JobsServiceBartender
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBartenderAmmo
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Bartender
+#     - !type:CharacterAgeRequirement
+#       min: 21
+#   items:
+#     - MagazineBoxRifle
+#
+# - type: loadout
+#   id: LoadoutServiceBartenderShotgunDoubleBarreled
+#   category: JobsServiceBartender
+#   cost: 0
+#   canBeHeirloom: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBartenderWeapon
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Bartender
+#     - !type:CharacterAgeRequirement
+#       min: 21
+#   items:
+#     - WeaponShotgunDoubleBarreledRubber # WWDP
+#
+# - type: loadout
+#   id: LoadoutServiceBartenderMosin
+#   category: JobsServiceBartender
+#   cost: 0
+#   canBeHeirloom: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBartenderWeapon
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Bartender
+#     - !type:CharacterAgeRequirement
+#       min: 21
+#   items:
+#     - WeaponSniperMosin
+#
+# - type: loadout
+#   id: LoadoutServiceBartenderBoxMagnum
+#   category: JobsServiceBartender
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBartenderAmmo
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Bartender
+#     - !type:CharacterAgeRequirement
+#       min: 21
+#   items:
+#     - MagazineBoxMagnum
+#
+# - type: loadout
+#   id: LoadoutServiceBartenderArgenti
+#   category: JobsServiceBartender
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBartenderWeapon
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Bartender
+#     - !type:CharacterAgeRequirement
+#       min: 21
+#   items:
+#     - WeaponRevolverArgenti
+#
+# - type: loadout
+#   id: LoadoutServiceBartenderRepeater
+#   category: JobsServiceBartender
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBartenderWeapon
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Bartender
+#     - !type:CharacterAgeRequirement
+#       min: 21
+#   items:
+#     - WeaponSniperRepeater
+# WWDP edit end
 
 # Eyes
 
@@ -201,19 +204,20 @@
   items:
   - ClothingOuterWinterBar
 
-- type: loadout
-  id: LoadoutServiceBartenderArmorDuraVest
-  category: JobsServiceBartender
-  cost: 0
-  exclusive: true
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutBartenderOuter
-    - !type:CharacterJobRequirement
-      jobs:
-        - Bartender
-  items:
-    - ClothingOuterArmorDuraVest
+# WWDP removed armor
+# - type: loadout
+#   id: LoadoutServiceBartenderArmorDuraVest
+#   category: JobsServiceBartender
+#   cost: 0
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutBartenderOuter
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - Bartender
+#   items:
+#     - ClothingOuterArmorDuraVest
 
 - type: loadout
   id: LoadoutServiceOuterBartenderNt

--- a/Resources/Prototypes/Loadouts/Jobs/Service/traitRestrictedGear.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Service/traitRestrictedGear.yml
@@ -1,80 +1,84 @@
-### Botanist
-## Equipment
-- type: loadout
-  id: LoadoutServiceRestrictedGearBotanistMiniHoe
-  category: JobsServiceBotanist
-  cost: 2
-  canBeHeirloom: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Botanist
-  items:
-    - HydroponicsToolMiniHoe
-- type: loadout
-  id: LoadoutServiceRestrictedGearBotanistClippers
-  category: JobsServiceBotanist
-  cost: 2
-  canBeHeirloom: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Botanist
-  items:
-    - HydroponicsToolClippers
-
-- type: loadout
-  id: LoadoutServiceRestrictedGearBotanistScythe
-  category: JobsServiceBotanist
-  cost: 2
-  canBeHeirloom: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Botanist
-  items:
-    - HydroponicsToolScythe
-
-- type: loadout
-  id: LoadoutServiceRestrictedGearBotanistHatchet
-  category: JobsServiceBotanist
-  cost: 2
-  canBeHeirloom: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Botanist
-  items:
-    - HydroponicsToolHatchet
-
-- type: loadout
-  id: LoadoutServiceRestrictedGearBotanistSpade
-  category: JobsServiceBotanist
-  cost: 2
-  canBeHeirloom: true
-  requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-        - RestrictedGear
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Botanist
-  items:
-    - HydroponicsToolSpade
+# WWDP edit start - trait removed
+#
+# ### Botanist
+# ## Equipment
+# - type: loadout
+#   id: LoadoutServiceRestrictedGearBotanistMiniHoe
+#   category: JobsServiceBotanist
+#   cost: 2
+#   canBeHeirloom: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - Botanist
+#   items:
+#     - HydroponicsToolMiniHoe
+# - type: loadout
+#   id: LoadoutServiceRestrictedGearBotanistClippers
+#   category: JobsServiceBotanist
+#   cost: 2
+#   canBeHeirloom: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - Botanist
+#   items:
+#     - HydroponicsToolClippers
+#
+# - type: loadout
+#   id: LoadoutServiceRestrictedGearBotanistScythe
+#   category: JobsServiceBotanist
+#   cost: 2
+#   canBeHeirloom: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - Botanist
+#   items:
+#     - HydroponicsToolScythe
+#
+# - type: loadout
+#   id: LoadoutServiceRestrictedGearBotanistHatchet
+#   category: JobsServiceBotanist
+#   cost: 2
+#   canBeHeirloom: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - Botanist
+#   items:
+#     - HydroponicsToolHatchet
+#
+# - type: loadout
+#   id: LoadoutServiceRestrictedGearBotanistSpade
+#   category: JobsServiceBotanist
+#   cost: 2
+#   canBeHeirloom: true
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       traits:
+#         - RestrictedGear
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - Botanist
+#   items:
+#     - HydroponicsToolSpade
+#
+# WWDP edit end

--- a/Resources/Prototypes/Maps/cyberiad.yml
+++ b/Resources/Prototypes/Maps/cyberiad.yml
@@ -1,77 +1,74 @@
-- type: gameMap
-  id: Cyberiad
-  mapName: 'Cyberiad Station'
-  mapPath: /Maps/cyberiad.yml
-  minPlayers: 30
-  maxPlayers: 85
-  stations:
-    Cyberiad:
-      stationProto: StandardNanotrasenStationCargoOnly
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} NSS Cyberiad {1}' # WWDP fix
-          nameGenerator: # WWDP fix
-            !type:NanotrasenNameGenerator
-            prefixCreator: '220'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_box.yml
-        - type: StationJobs
-          availableJobs:
-            #service
-            Captain: [ 1, 1 ]
-            Maid: [ 1, 1 ] # WWDP Combat Maid instead of CC roles
-            HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
-            Botanist: [ 3, 3 ]
-            Chef: [ 2, 2 ]
-            Janitor: [ 2, 2 ]
-            Chaplain: [ 1, 1 ]
-            Librarian: [ 1, 1 ]
-            #engineering
-            ChiefEngineer: [ 1, 1 ]
-            AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 5, 5 ]
-            TechnicalAssistant: [ 4, 4 ]
-            SeniorEngineer: [ 1, 1 ]
-            #medical
-            ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 4 ]
-            Paramedic: [ 1, 1 ]
-            MedicalIntern: [ 4, 4 ]
-            Psychologist: [ 1, 1 ]
-            SeniorPhysician: [ 1, 1 ]
-            #science
-            ResearchDirector: [ 1, 1 ]
-            Scientist: [ 5, 5 ]
-            Roboticist: [ 1, 2 ]
-            ResearchAssistant: [ 4, 4 ]
-            ForensicMantis: [ 1, 1 ]
-            SeniorResearcher: [ 1, 1 ]
-            #security
-            HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 5, 5 ]
-            Brigmedic: [ 1, 1 ]
-            Prisoner: [ 1, 3 ]
-            PrisonGuard: [ 1, 2 ]
-            Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
-            Lawyer: [ 2, 2 ]
-            SeniorOfficer: [ 1, 1 ]
-            #supply
-            Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 3, 5 ]
-            MailCarrier: [ 1, 2 ]
-            #civilian
-            Passenger: [ -1, -1 ]
-            Clown: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 2 ]
-            Reporter: [ 1, 1 ]
-            #silicon
-            StationAi: [ 1, 1 ]
-            Borg: [ 2, 2 ]
-            MedicalBorg: [ 2, 2 ]
+#- type: gameMap
+#  id: Cyberiad
+#  mapName: 'Cyberiad Station'
+#  mapPath: /Maps/cyberiad.yml
+#  minPlayers: 30
+#  maxPlayers: 85
+#  stations:
+#    Cyberiad:
+#      stationProto: StandardNanotrasenStationCargoOnly
+#      components:
+#        - type: StationNameSetup
+#          mapNameTemplate: 'NSS Cyberiad {1}'
+#        - type: StationEmergencyShuttle
+#          emergencyShuttlePath: /Maps/Shuttles/emergency_box.yml
+#        - type: StationJobs
+#          availableJobs:
+#            #service
+#            Captain: [ 1, 1 ]
+#            Maid: [ 1, 1 ] # WWDP Combat Maid instead of CC roles
+#            HeadOfPersonnel: [ 1, 1 ]
+#            Bartender: [ 2, 2 ]
+#            Botanist: [ 3, 3 ]
+#            Chef: [ 2, 2 ]
+#            Janitor: [ 2, 2 ]
+#            Chaplain: [ 1, 1 ]
+#            Librarian: [ 1, 1 ]
+#            #engineering
+#            ChiefEngineer: [ 1, 1 ]
+#            AtmosphericTechnician: [ 3, 3 ]
+#            StationEngineer: [ 5, 5 ]
+#            TechnicalAssistant: [ 4, 4 ]
+#            SeniorEngineer: [ 1, 1 ]
+#            #medical
+#            ChiefMedicalOfficer: [ 1, 1 ]
+#            Chemist: [ 2, 2 ]
+#            MedicalDoctor: [ 4, 4 ]
+#            Paramedic: [ 1, 1 ]
+#            MedicalIntern: [ 4, 4 ]
+#            Psychologist: [ 1, 1 ]
+#            SeniorPhysician: [ 1, 1 ]
+#            #science
+#            ResearchDirector: [ 1, 1 ]
+#            Scientist: [ 5, 5 ]
+#            Roboticist: [ 1, 2 ]
+#            ResearchAssistant: [ 4, 4 ]
+#            ForensicMantis: [ 1, 1 ]
+#            SeniorResearcher: [ 1, 1 ]
+#            #security
+#            HeadOfSecurity: [ 1, 1 ]
+#            Warden: [ 1, 1 ]
+#            SecurityOfficer: [ 5, 5 ]
+#            Brigmedic: [ 1, 1 ]
+#            Prisoner: [ 1, 3 ]
+#            PrisonGuard: [ 1, 2 ]
+#            Detective: [ 1, 1 ]
+#            SecurityCadet: [ 4, 4 ]
+#            Lawyer: [ 2, 2 ]
+#            SeniorOfficer: [ 1, 1 ]
+#            #supply
+#            Quartermaster: [ 1, 1 ]
+#            SalvageSpecialist: [ 3, 3 ]
+#            CargoTechnician: [ 3, 5 ]
+#            MailCarrier: [ 1, 2 ]
+#            #civilian
+#            Passenger: [ -1, -1 ]
+#            Clown: [ 1, 1 ]
+#            Mime: [ 1, 1 ]
+#            Musician: [ 1, 2 ]
+#            Reporter: [ 1, 1 ]
+#            #silicon
+#            StationAi: [ 1, 1 ]
+#            Borg: [ 2, 2 ]
+#            MedicalBorg: [ 2, 2 ]
 

--- a/Resources/Prototypes/Maps/cyberiad.yml
+++ b/Resources/Prototypes/Maps/cyberiad.yml
@@ -1,74 +1,77 @@
-#- type: gameMap
-#  id: Cyberiad
-#  mapName: 'Cyberiad Station'
-#  mapPath: /Maps/cyberiad.yml
-#  minPlayers: 30
-#  maxPlayers: 85
-#  stations:
-#    Cyberiad:
-#      stationProto: StandardNanotrasenStationCargoOnly
-#      components:
-#        - type: StationNameSetup
-#          mapNameTemplate: 'NSS Cyberiad {1}'
-#        - type: StationEmergencyShuttle
-#          emergencyShuttlePath: /Maps/Shuttles/emergency_box.yml
-#        - type: StationJobs
-#          availableJobs:
-#            #service
-#            Captain: [ 1, 1 ]
-#            Maid: [ 1, 1 ] # WWDP Combat Maid instead of CC roles
-#            HeadOfPersonnel: [ 1, 1 ]
-#            Bartender: [ 2, 2 ]
-#            Botanist: [ 3, 3 ]
-#            Chef: [ 2, 2 ]
-#            Janitor: [ 2, 2 ]
-#            Chaplain: [ 1, 1 ]
-#            Librarian: [ 1, 1 ]
-#            #engineering
-#            ChiefEngineer: [ 1, 1 ]
-#            AtmosphericTechnician: [ 3, 3 ]
-#            StationEngineer: [ 5, 5 ]
-#            TechnicalAssistant: [ 4, 4 ]
-#            SeniorEngineer: [ 1, 1 ]
-#            #medical
-#            ChiefMedicalOfficer: [ 1, 1 ]
-#            Chemist: [ 2, 2 ]
-#            MedicalDoctor: [ 4, 4 ]
-#            Paramedic: [ 1, 1 ]
-#            MedicalIntern: [ 4, 4 ]
-#            Psychologist: [ 1, 1 ]
-#            SeniorPhysician: [ 1, 1 ]
-#            #science
-#            ResearchDirector: [ 1, 1 ]
-#            Scientist: [ 5, 5 ]
-#            Roboticist: [ 1, 2 ]
-#            ResearchAssistant: [ 4, 4 ]
-#            ForensicMantis: [ 1, 1 ]
-#            SeniorResearcher: [ 1, 1 ]
-#            #security
-#            HeadOfSecurity: [ 1, 1 ]
-#            Warden: [ 1, 1 ]
-#            SecurityOfficer: [ 5, 5 ]
-#            Brigmedic: [ 1, 1 ]
-#            Prisoner: [ 1, 3 ]
-#            PrisonGuard: [ 1, 2 ]
-#            Detective: [ 1, 1 ]
-#            SecurityCadet: [ 4, 4 ]
-#            Lawyer: [ 2, 2 ]
-#            SeniorOfficer: [ 1, 1 ]
-#            #supply
-#            Quartermaster: [ 1, 1 ]
-#            SalvageSpecialist: [ 3, 3 ]
-#            CargoTechnician: [ 3, 5 ]
-#            MailCarrier: [ 1, 2 ]
-#            #civilian
-#            Passenger: [ -1, -1 ]
-#            Clown: [ 1, 1 ]
-#            Mime: [ 1, 1 ]
-#            Musician: [ 1, 2 ]
-#            Reporter: [ 1, 1 ]
-#            #silicon
-#            StationAi: [ 1, 1 ]
-#            Borg: [ 2, 2 ]
-#            MedicalBorg: [ 2, 2 ]
+- type: gameMap
+  id: Cyberiad
+  mapName: 'Cyberiad Station'
+  mapPath: /Maps/cyberiad.yml
+  minPlayers: 30
+  maxPlayers: 85
+  stations:
+    Cyberiad:
+      stationProto: StandardNanotrasenStationCargoOnly
+      components:
+        - type: StationNameSetup
+          mapNameTemplate: '{0} NSS Cyberiad {1}' # WWDP fix
+          nameGenerator: # WWDP fix
+            !type:NanotrasenNameGenerator
+            prefixCreator: '220'
+        - type: StationEmergencyShuttle
+          emergencyShuttlePath: /Maps/Shuttles/emergency_box.yml
+        - type: StationJobs
+          availableJobs:
+            #service
+            Captain: [ 1, 1 ]
+            Maid: [ 1, 1 ] # WWDP Combat Maid instead of CC roles
+            HeadOfPersonnel: [ 1, 1 ]
+            Bartender: [ 2, 2 ]
+            Botanist: [ 3, 3 ]
+            Chef: [ 2, 2 ]
+            Janitor: [ 2, 2 ]
+            Chaplain: [ 1, 1 ]
+            Librarian: [ 1, 1 ]
+            #engineering
+            ChiefEngineer: [ 1, 1 ]
+            AtmosphericTechnician: [ 3, 3 ]
+            StationEngineer: [ 5, 5 ]
+            TechnicalAssistant: [ 4, 4 ]
+            SeniorEngineer: [ 1, 1 ]
+            #medical
+            ChiefMedicalOfficer: [ 1, 1 ]
+            Chemist: [ 2, 2 ]
+            MedicalDoctor: [ 4, 4 ]
+            Paramedic: [ 1, 1 ]
+            MedicalIntern: [ 4, 4 ]
+            Psychologist: [ 1, 1 ]
+            SeniorPhysician: [ 1, 1 ]
+            #science
+            ResearchDirector: [ 1, 1 ]
+            Scientist: [ 5, 5 ]
+            Roboticist: [ 1, 2 ]
+            ResearchAssistant: [ 4, 4 ]
+            ForensicMantis: [ 1, 1 ]
+            SeniorResearcher: [ 1, 1 ]
+            #security
+            HeadOfSecurity: [ 1, 1 ]
+            Warden: [ 1, 1 ]
+            SecurityOfficer: [ 5, 5 ]
+            Brigmedic: [ 1, 1 ]
+            Prisoner: [ 1, 3 ]
+            PrisonGuard: [ 1, 2 ]
+            Detective: [ 1, 1 ]
+            SecurityCadet: [ 4, 4 ]
+            Lawyer: [ 2, 2 ]
+            SeniorOfficer: [ 1, 1 ]
+            #supply
+            Quartermaster: [ 1, 1 ]
+            SalvageSpecialist: [ 3, 3 ]
+            CargoTechnician: [ 3, 5 ]
+            MailCarrier: [ 1, 2 ]
+            #civilian
+            Passenger: [ -1, -1 ]
+            Clown: [ 1, 1 ]
+            Mime: [ 1, 1 ]
+            Musician: [ 1, 2 ]
+            Reporter: [ 1, 1 ]
+            #silicon
+            StationAi: [ 1, 1 ]
+            Borg: [ 2, 2 ]
+            MedicalBorg: [ 2, 2 ]
 

--- a/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Lockers/epistemics.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Lockers/epistemics.yml
@@ -15,12 +15,13 @@
       # Spare change of clothes
       # - id: ClothingUniformJumpsuitMantis
       # - id: ClothingUniformSkirtMantis
-      # - id: ClothingBeltMantis
+      - id: ClothingBeltMantis # WWDP
       # - id: ClothingShoesBootsMantis
       # - id: ClothingHandsGlovesForensic # Deltav - Detective is in charge of investigating crimes.
       - id: ClothingHeadHatFezMantis
-      # - id: ClothingOuterCoatMantis
+      - id: ClothingOuterCoatMantis # WWDP
       - id: ClothingOuterWinterCoatMantis
+      - id: ClothingEyesHudEpistemics # WWDP
       # - id: ClothingEyesGlassesSunglasses
       # Insulative headgear
       - id: ClothingHeadTinfoil

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -63,11 +63,11 @@
     shoes: ClothingShoesBootsMantis
     head: ClothingHeadHatFezMantis
     id: ForensicMantisPDA
-    eyes: ClothingEyesGlassesSunglasses
+    # eyes: ClothingEyesGlassesSunglasses # WWDP disable
     ears: ClothingHeadsetScience # DeltaV - Mantis is part of Epistemics
     gloves: ClothingHandsGlovesColorWhite
-    outerClothing: ClothingOuterCoatMantis
-    belt: ClothingBeltMantis
+    # outerClothing: ClothingOuterCoatMantis # WWDP moved to locker
+    # belt: ClothingBeltMantis # WWDP moved to locker
     pocket1: BookPsionicsGuidebook
   innerClothingSkirt: ClothingUniformSkirtMantis
   satchel: ClothingBackpackSatchelMantisFilled

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
@@ -37,16 +37,16 @@
   - PrisonGuardPlasmamanGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitPrisonGuard
-    back: ClothingBackpackSecurityFilled
-    shoes: ClothingShoesBootsCombatFilled
-    eyes: ClothingEyesGlassesSecurity
+    back: ClothingBackpackSecurity # WWDP
+    shoes: ClothingShoesBootsJack # WWDP
+    # eyes: ClothingEyesGlassesSecurity # WWDP
     head: ClothingHeadPrisonGuard
     id: PrisonGuardPDA
     ears: ClothingHeadsetPrisonGuard #DeltaV
-    belt: ClothingBeltSecurityFilled
+    belt: WeaponEnergyGunPistolSecurity  # WWDP
   innerClothingSkirt: ClothingUniformJumpsuitPrisonGuard
-  satchel: ClothingBackpackSatchelSecurityFilled
-  duffelbag: ClothingBackpackDuffelSecurityFilled
+  satchel: ClothingBackpackSatchelSecurity # WWDP
+  duffelbag: ClothingBackpackDuffelSecurity # WWDP
 
 - type: startingGear
   id: PrisonGuardPlasmamanGear

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -30,10 +30,10 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitSalvageSpecialist
     back: ClothingBackpackSalvageFilled
-    shoes: ClothingShoesBootsSalvage
+    shoes: ClothingShoesBootsSalvageFilled # WWDP
     id: SalvagePDA
     ears: ClothingHeadsetCargo
-    pocket1: MiningVoucher
+    # pocket1: MiningVoucher # WWDP
   satchel: ClothingBackpackSatchelSalvageFilled
   duffelbag: ClothingBackpackDuffelSalvageFilled
 

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -49,7 +49,7 @@
   - ChaplainPlasmamanGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitChaplain
-    back: ClothingBackpack
+    back: ClothingBackpackChaplainFilled
     shoes: ClothingShoesColorBlack
     id: ChaplainPDA
     ears: ClothingHeadsetScience

--- a/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
@@ -51,7 +51,7 @@
     jumpsuit: ClothingUniformJumpsuitLibrarian
     back: ClothingBackpackLibrarianFilled
     shoes: ClothingShoesBootsLaceup
-    outerClothing: ClothingOuterCoatRnd
+    # outerClothing: ClothingOuterCoatRnd # WWDP disabled
     id: LibrarianPDA
     ears: ClothingHeadsetScience
     pocket1: BookPsionicsGuidebook

--- a/Resources/Prototypes/Roles/Jobs/Engineering/senior_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/senior_engineer.yml
@@ -40,8 +40,8 @@
     back: ClothingBackpackEngineeringFilled
     shoes: ClothingShoesBootsWork
     id: SeniorEngineerPDA
-    eyes: ClothingEyesGlassesMeson
-    belt: ClothingBeltUtilityEngineering
+    # eyes: ClothingEyesGlassesMeson # WWDP
+    # belt: ClothingBeltUtilityEngineering # WWDP
     ears: ClothingHeadsetEngineering
   innerClothingSkirt: ClothingUniformJumpskirtSeniorEngineer
   satchel: ClothingBackpackSatchelEngineeringFilled

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -34,8 +34,8 @@
     back: ClothingBackpackEngineeringFilled
     shoes: ClothingShoesBootsWork
     id: EngineerPDA
-    eyes: ClothingEyesGlassesMeson
-    belt: ClothingBeltUtilityEngineering
+    # eyes: ClothingEyesGlassesMeson # WWDP
+    # belt: ClothingBeltUtilityEngineering # WWDP
     ears: ClothingHeadsetEngineering
   innerClothingSkirt: ClothingUniformJumpskirtEngineering
   satchel: ClothingBackpackSatchelEngineeringFilled

--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -28,7 +28,7 @@
     back: ClothingBackpackEngineeringFilled
     shoes: ClothingShoesBootsWork
     id: TechnicalAssistantPDA
-    belt: ClothingBeltUtilityEngineering
+    # belt: ClothingBeltUtilityEngineering # WWDP
     ears: ClothingHeadsetEngineering
     pocket1: BookEngineersHandbook
   innerClothingSkirt: ClothingUniformJumpskirtColorYellow

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -44,9 +44,9 @@
     shoes: ClothingShoesColorBlue
     id: ParamedicPDA
     ears: ClothingHeadsetMedical
-    belt: ClothingBeltMedicalEMTFilled
-    pocket1: HandheldGPSBasic
-    pocket2: HandheldCrewMonitor
+    # belt: ClothingBeltMedicalEMTFilled # WWDP moved to locker
+    # pocket1: HandheldGPSBasic # WWDP moved to locker
+    # pocket2: HandheldCrewMonitor # WWDP moved to locker
   innerClothingSkirt: ClothingUniformJumpskirtParamedic
   satchel: ClothingBackpackSatchelParamedicFilledDV
   duffelbag: ClothingBackpackDuffelParamedicFilledDV

--- a/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
@@ -44,7 +44,7 @@
     outerClothing: ClothingOuterCoatLabSeniorPhysician
     id: SeniorPhysicianPDA
     ears: ClothingHeadsetMedical
-    belt: ClothingBeltMedicalFilled
+    # belt: ClothingBeltMedicalFilled # WWDP moved to lockers
   innerClothingSkirt: ClothingUniformJumpskirtSeniorPhysician
   satchel: ClothingBackpackSatchelMedicalFilled
   duffelbag: ClothingBackpackDuffelMedicalFilled

--- a/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
@@ -26,7 +26,7 @@
     jumpsuit: ClothingUniformJumpsuitScientist
     back: ClothingBackpackScienceFilled
     shoes: ClothingShoesColorWhite
-    outerClothing: ClothingOuterCoatRnd
+    # outerClothing: ClothingOuterCoatRnd # WWDP disabled
     id: SciencePDA
     ears: ClothingHeadsetScience
     pocket1: BookPsionicsGuidebook

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -52,10 +52,10 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitDetective
     back: ClothingBackpackSecurity
-    shoes: ClothingShoesBootsCombatFilled
-    eyes: ClothingEyesGlassesSunglasses
+    shoes: ClothingShoesBootsJack # WWDP
+    # eyes: ClothingEyesGlassesSunglasses # WWDP
     head: ClothingHeadHatFedoraBrown
-    outerClothing: ClothingOuterVestDetective
+    # outerClothing: ClothingOuterVestDetective # WWDP
     id: DetectivePDA
     ears: ClothingHeadsetAltSecurityRegular # Goobstation
     belt: ClothingBeltHolsterFilled

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -57,12 +57,12 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitHoS
     back: ClothingBackpackHOSFilled
-    shoes: ClothingShoesBootsCombatFilled
-    eyes: ClothingEyesGlassesSunglasses
+    shoes: ClothingShoesBootsCombatFilled # WWDP combat boots for protag energy
+    # eyes: ClothingEyesGlassesSunglasses # WWDP
     id: HoSPDA
-    gloves: ClothingHandsGlovesCombat
+    # gloves: ClothingHandsGlovesCombat # WWDP
     ears: ClothingHeadsetAltSecurity
-    belt: ClothingBeltSecurityFilled
+    belt: WeaponEnergyGunMultiphase # WWDP
   innerClothingSkirt: ClothingUniformJumpskirtHoS
   satchel: ClothingBackpackSatchelHOSFilled
   duffelbag: ClothingBackpackDuffelHOSFilled

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -46,11 +46,11 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitColorRed
     back: ClothingBackpackSecurity
-    shoes: ClothingShoesBootsCombatFilled
-    outerClothing: ClothingOuterArmorDuraVest # DeltaV - ClothingOuterArmorBasic replaced in favour of stab vest. Sucks to suck, cadets
+    shoes: ClothingShoesBootsJack # WWDP
+    # outerClothing: ClothingOuterArmorDuraVest # DeltaV - ClothingOuterArmorBasic replaced in favour of stab vest. Sucks to suck, cadets  # WWDP
     id: SecurityCadetPDA
     ears: ClothingHeadsetAltSecurityRegular # Goobstation
-    belt: ClothingBeltSecurityFilled
+    belt: WeaponEnergyGunPistolSecurity  # WWDP moved to lockers, same as armor
     pocket1: BookSecurity
   innerClothingSkirt: ClothingUniformJumpskirtColorRed
   satchel: ClothingBackpackSatchelSecurity

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -51,13 +51,13 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitSec
     back: ClothingBackpackSecurity
-    shoes: ClothingShoesBootsCombatFilled
-    eyes: ClothingEyesGlassesSunglasses
-    head: ClothingHeadHelmetBasic
-    outerClothing: ClothingOuterArmorPlateCarrier # DeltaV - ClothingOuterArmorBasic replaced in favour of plate carrier
+    shoes: ClothingShoesBootsJack # WWDP
+    # eyes: ClothingEyesGlassesSunglasses # WWDP moved everything to lockers
+    # head: ClothingHeadHelmetBasic # WWDP
+    # outerClothing: ClothingOuterArmorPlateCarrier # DeltaV - ClothingOuterArmorBasic replaced in favour of plate carrier # WWDP
     id: SecurityPDA
     ears: ClothingHeadsetAltSecurityRegular # Goobstation
-    belt: ClothingBeltSecurityFilled
+    belt: WeaponEnergyGunPistolSecurity  # WWDP
   innerClothingSkirt: ClothingUniformJumpskirtSec
   satchel: ClothingBackpackSatchelSecurity
   duffelbag: ClothingBackpackDuffelSecurity

--- a/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
@@ -60,13 +60,13 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitSeniorOfficer
     back: ClothingBackpackSecurity
-    shoes: ClothingShoesBootsCombatFilled
-    eyes: ClothingEyesGlassesSecurity
+    shoes: ClothingShoesBootsJack # WWDP
+    # eyes: ClothingEyesGlassesSecurity # WWDP
     head: ClothingHeadHatBeretSecurity
-    outerClothing: ClothingOuterArmorPlateCarrier # DeltaV - ClothingOuterArmorBasic replaced in favour of plate carrier
+    # outerClothing: ClothingOuterArmorPlateCarrier # DeltaV - ClothingOuterArmorBasic replaced in favour of plate carrier # WWDP
     id: SeniorOfficerPDA
     ears: ClothingHeadsetSecurity
-    belt: ClothingBeltSecurityFilled
+    belt: WeaponEnergyGunPistolSecurity  # WWDP
   innerClothingSkirt: ClothingUniformJumpskirtSeniorOfficer
   satchel: ClothingBackpackSatchelSecurity
   duffelbag: ClothingBackpackDuffelSecurity

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -57,12 +57,12 @@
     head: ClothingHeadHatWarden
     jumpsuit: ClothingUniformJumpsuitWarden
     back: ClothingBackpackSecurity
-    shoes: ClothingShoesBootsCombatFilled
-    eyes: ClothingEyesGlassesSunglasses
-    outerClothing: ClothingOuterCoatWarden
+    shoes: ClothingShoesBootsJack # WWDP
+    # eyes: ClothingEyesGlassesSunglasses # WWDP
+    # outerClothing: ClothingOuterCoatWarden # WWDP
     id: WardenPDA
     ears: ClothingHeadsetAltSecurityRegular # Goobstation
-    belt: ClothingBeltSecurityFilled
+    belt: WeaponEnergyGunPistolSecurity  # WWDP
   innerClothingSkirt: ClothingUniformJumpskirtWarden
   satchel: ClothingBackpackSatchelSecurity
   duffelbag: ClothingBackpackDuffelSecurity

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
@@ -28,7 +28,7 @@
     shoes: ClothingShoesLeather
     id: PsychologistPDA
     ears: ClothingHeadsetMedical
-    pocket2: CandyBucket
+    # pocket2: CandyBucket # WWDP
   innerClothingSkirt: ClothingUniformJumpsuitPsychologist
   satchel: ClothingBackpackSatchelPsychologistFilled #DeltaV - stamp included
   duffelbag: ClothingBackpackDuffelPsychologistFilled #DeltaV - stamp included

--- a/Resources/Prototypes/_White/Catalog/Fills/Items/shoes.yml
+++ b/Resources/Prototypes/_White/Catalog/Fills/Items/shoes.yml
@@ -1,0 +1,9 @@
+﻿- type: entity
+  id: ClothingShoesBootsSalvageFilled
+  parent: ClothingShoesBootsSalvage
+  suffix: Filled
+  components:
+  - type: ContainerFill
+    containers:
+      item:
+      - SurvivalKnife

--- a/Resources/Prototypes/_White/Catalog/VendingMachines/Inventories/CaptainDrobeInventory.yml
+++ b/Resources/Prototypes/_White/Catalog/VendingMachines/Inventories/CaptainDrobeInventory.yml
@@ -13,6 +13,7 @@
     ClothingNeckMantleCap: 1
     ClothingOuterWinterCap: 1
     ClothingOuterArmorCaptainCarapace: 1
+    ClothingOuterCoatCapTrench: 1 # WWDP moved from the locker
     ClothingOuterCoatCaptain: 1
     ClothingUniformJumpsuitCaptain: 1
     ClothingUniformJumpskirtCaptain: 1

--- a/Resources/Prototypes/_White/Loadouts/Jobs/captain.yml
+++ b/Resources/Prototypes/_White/Loadouts/Jobs/captain.yml
@@ -1,0 +1,13 @@
+﻿- type: loadout
+  id: LoadoutCommandCapJumpsuitCommand
+  category: JobsCommandCaptain
+  cost: 0
+  exclusive: true
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutCaptainUniforms
+  - !type:CharacterJobRequirement
+    jobs:
+    - Captain
+  items:
+  - ClothingUniformJumpsuitCommandCaptain

--- a/Resources/Prototypes/_White/Loadouts/Jobs/headOfSecurity.yml
+++ b/Resources/Prototypes/_White/Loadouts/Jobs/headOfSecurity.yml
@@ -1,13 +1,14 @@
-- type: loadout
-  id: LoadoutCommandHoSBat
-  category: JobsSecurityHeadOfSecurity
-  cost: 0
-  canBeHeirloom: true
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutHeadOfSecurityWeapon
-  - !type:CharacterJobRequirement
-    jobs:
-    - HeadOfSecurity
-  items:
-  - AssballBat
+# moved to locker
+# - type: loadout
+#   id: LoadoutCommandHoSBat
+#   category: JobsSecurityHeadOfSecurity
+#   cost: 0
+#   canBeHeirloom: true
+#   requirements:
+#   - !type:CharacterItemGroupRequirement
+#     group: LoadoutHeadOfSecurityWeapon
+#   - !type:CharacterJobRequirement
+#     jobs:
+#     - HeadOfSecurity
+#   items:
+#   - AssballBat


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

- Уменьшено количество опций для раундстарт манча через лодауты
- Большинство вещей из стартового снаряжения/лодаутов перенесено в шкафы ролей
- Телескопички вернулись главам в сумки при спавне
- Табельное оружие СБ стандартизировано, убрана возможность выбора через лодауты
- Ружьё бармена вернулось в шкаф
- Убран блоат и неактуальные опции в лодаутах
- Убраны платы антимова со станции
- Ещё много чего по мелочи, увидите в игре

:cl: vanx
- tweak: Глобальное обновление стартового снаряжения, лодаутов и шкафов всех ролей
