### PR TITLE
[Fix] Role Timers

### DIFF
--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
@@ -3,13 +3,14 @@
   name: job-name-brigmedic
   description: job-description-brigmedic
   playTimeTracker: JobBrigmedic
+  setPreference: false # WWDP disabled role, not mapped
   requirements:
-    - !type:CharacterDepartmentTimeRequirement
-      department: Medical
-      min: 21600 # 6 hrs
-    - !type:CharacterDepartmentTimeRequirement
-      department: Security
-      min: 18000 # 4 hrs
+    # - !type:CharacterDepartmentTimeRequirement # WWDP
+    #   department: Medical
+    #   min: 21600 # 6 hrs
+    # - !type:CharacterDepartmentTimeRequirement
+    #   department: Security
+    #   min: 18000 # 4 hrs
     - !type:CharacterTraitRequirement
       inverted: true
       traits:

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -4,11 +4,11 @@
   description: job-description-mantis
   playTimeTracker: JobForensicMantis
   requirements:
-    - !type:CharacterOverallTimeRequirement
-      min: 18000
-    - !type:CharacterDepartmentTimeRequirement
-      department: Epistemics # DeltaV - Epistemics Department replacing Science
-      min: 3600
+    # - !type:CharacterOverallTimeRequirement # WWDP
+    #   min: 18000
+    # - !type:CharacterDepartmentTimeRequirement
+    #   department: Epistemics # DeltaV - Epistemics Department replacing Science
+    #   min: 3600
     - !type:CharacterLogicOrRequirement
       requirements:
         - !type:CharacterSpeciesRequirement

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
@@ -8,7 +8,7 @@
   canBeAntag: false
   icon: "JobIconPrisonGuard"
   supervisors: job-supervisors-warden
-  setPreference: true
+  setPreference: false # WWDP disabled role, not mapped
 #  whitelistRequired: true
   access:
   - Security

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
@@ -10,9 +10,9 @@
   icon: "JobIconPrisoner"
   supervisors: job-supervisors-security
   requirements:
-  - !type:CharacterDepartmentTimeRequirement
-    department: Security
-    min: 21600
+  # - !type:CharacterDepartmentTimeRequirement # WWDP
+  #   department: Security
+  #   min: 21600
   - !type:CharacterLogicOrRequirement
     requirements:
     - !type:CharacterSpeciesRequirement

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -4,9 +4,9 @@
   description: job-description-salvagespec
   playTimeTracker: JobSalvageSpecialist
   requirements:
-    - !type:CharacterDepartmentTimeRequirement
-      department: Logistics # DeltaV - Logistics Department replacing Cargo
-      min: 21600 #DeltaV 6 hrs
+    # - !type:CharacterDepartmentTimeRequirement # WWDP
+    #   department: Logistics # DeltaV - Logistics Department replacing Cargo
+    #   min: 21600 #DeltaV 6 hrs
     - !type:CharacterEmployerRequirement
       employers:
       - OrionExpress

--- a/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
@@ -4,9 +4,9 @@
   description: job-description-bartender
   playTimeTracker: JobBartender
   requirements:
-    - !type:CharacterDepartmentTimeRequirement
-      department: Civilian
-      min: 3600 #DeltaV
+    # - !type:CharacterDepartmentTimeRequirement # WWDP
+    #   department: Civilian
+    #   min: 3600 #DeltaV
     - !type:CharacterEmployerRequirement
       employers:
       - IdrisIncorporated

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -4,9 +4,9 @@
   description: job-description-chaplain
   playTimeTracker: JobChaplain
   requirements:
-    - !type:CharacterDepartmentTimeRequirement
-      department: Epistemics # Chaplain is now one of the station's "Crew-Aligned Wizards"
-      min: 14400 # 4 hours
+    # - !type:CharacterDepartmentTimeRequirement # WWDP
+    #   department: Epistemics # Chaplain is now one of the station's "Crew-Aligned Wizards"
+    #   min: 14400 # 4 hours
     - !type:CharacterLogicOrRequirement
       requirements:
         - !type:CharacterSpeciesRequirement

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
@@ -4,9 +4,9 @@
   description: job-description-chef
   playTimeTracker: JobChef
   requirements:
-    - !type:CharacterDepartmentTimeRequirement
-      department: Civilian
-      min: 3600 #DeltaV 1 hour
+    # - !type:CharacterDepartmentTimeRequirement # WWDP
+    #   department: Civilian
+    #   min: 3600 #DeltaV 1 hour
     - !type:CharacterEmployerRequirement
       employers:
       - NanoTrasen

--- a/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
@@ -4,9 +4,9 @@
   description: job-description-librarian
   playTimeTracker: JobLibrarian
   requirements:
-    - !type:CharacterDepartmentTimeRequirement
-      department: Epistemics
-      min: 14400
+    # - !type:CharacterDepartmentTimeRequirement # WWDP
+    #   department: Epistemics
+    #   min: 14400
     - !type:CharacterLogicOrRequirement
       requirements:
         - !type:CharacterSpeciesRequirement

--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -4,9 +4,9 @@
   description: job-description-atmostech
   playTimeTracker: JobAtmosphericTechnician
   requirements:
-    - !type:CharacterDepartmentTimeRequirement
-      department: Engineering
-      min: 36000 # DeltaV - 10 hours
+    # - !type:CharacterDepartmentTimeRequirement # WWDP
+    #   department: Engineering
+    #   min: 36000 # DeltaV - 10 hours
     - !type:CharacterEmployerRequirement
       employers:
       - HephaestusIndustries

--- a/Resources/Prototypes/Roles/Jobs/Engineering/senior_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/senior_engineer.yml
@@ -3,16 +3,17 @@
   name: job-name-senior-engineer
   description: job-description-senior-engineer
   playTimeTracker: JobSeniorEngineer
+  setPreference: false # WWDP disabled role, not mapped
   requirements:
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobAtmosphericTechnician
-      min: 21600 #6 hrs
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobStationEngineer
-      min: 21600 #6 hrs
-    - !type:CharacterDepartmentTimeRequirement
-      department: Engineering
-      min: 216000 # 60 hrs
+    # - !type:CharacterPlaytimeRequirement # WWDP
+    #   tracker: JobAtmosphericTechnician
+    #   min: 21600 #6 hrs
+    # - !type:CharacterPlaytimeRequirement
+    #   tracker: JobStationEngineer
+    #   min: 21600 #6 hrs
+    # - !type:CharacterDepartmentTimeRequirement
+    #   department: Engineering
+    #   min: 216000 # 60 hrs
     - !type:CharacterEmployerRequirement
       employers:
       - HephaestusIndustries

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -4,9 +4,9 @@
   description: job-description-engineer
   playTimeTracker: JobStationEngineer
   requirements:
-    - !type:CharacterDepartmentTimeRequirement
-      department: Engineering
-      min: 14400 #4 hrs
+    # - !type:CharacterDepartmentTimeRequirement # WWDP
+    #   department: Engineering
+    #   min: 14400 #4 hrs
     - !type:CharacterEmployerRequirement
       employers:
       - HephaestusIndustries

--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -4,9 +4,9 @@
   description: job-description-chemist
   playTimeTracker: JobChemist
   requirements:
-    - !type:CharacterDepartmentTimeRequirement
-      department: Medical
-      min: 28800 # DeltaV - 8 hours
+    # - !type:CharacterDepartmentTimeRequirement # WWDP
+    #   department: Medical
+    #   min: 28800 # DeltaV - 8 hours
     - !type:CharacterEmployerRequirement
       employers:
       - ZengHuPharmaceuticals

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
@@ -4,9 +4,9 @@
   description: job-description-doctor
   playTimeTracker: JobMedicalDoctor
   requirements:
-    - !type:CharacterDepartmentTimeRequirement
-      department: Medical
-      min: 14400 #4 hrs
+    # - !type:CharacterDepartmentTimeRequirement # WWDP
+    #   department: Medical
+    #   min: 14400 #4 hrs
     - !type:CharacterEmployerRequirement
       employers:
       - ZengHuPharmaceuticals

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -7,9 +7,9 @@
     # - !type:RoleTimeRequirement # DeltaV - No Medical Doctor time requirement
     #   role: JobMedicalDoctor
     #   time: 14400 #4 hrs
-    - !type:CharacterDepartmentTimeRequirement # DeltaV - Medical dept time requirement
-      department: Medical
-      min: 28800 # DeltaV - 8 hours
+    # - !type:CharacterDepartmentTimeRequirement # DeltaV - Medical dept time requirement # WWDP
+    #   department: Medical
+    #   min: 28800 # DeltaV - 8 hours
     - !type:CharacterEmployerRequirement
       employers:
       - Interdyne

--- a/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
@@ -3,16 +3,17 @@
   name: job-name-senior-physician
   description: job-description-senior-physician
   playTimeTracker: JobSeniorPhysician
+  setPreference: false # WWDP disabled role, not mapped
   requirements:
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobChemist
-      min: 21600 #6 hrs
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobMedicalDoctor
-      min: 21600 #6 hrs
-    - !type:CharacterDepartmentTimeRequirement
-      department: Medical
-      min: 216000 # 60 hrs
+    # - !type:CharacterPlaytimeRequirement # WWDP
+    #   tracker: JobChemist
+    #   min: 21600 #6 hrs
+    # - !type:CharacterPlaytimeRequirement
+    #   tracker: JobMedicalDoctor
+    #   min: 21600 #6 hrs
+    # - !type:CharacterDepartmentTimeRequirement
+    #   department: Medical
+    #   min: 216000 # 60 hrs
     - !type:CharacterEmployerRequirement
       employers:
       - ZengHuPharmaceuticals

--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -12,6 +12,9 @@
   spawnLoadout: false
   applyTraits: false
   canHavePassport: false
+  requirements:
+  - !type:CharacterOverallTimeRequirement # WWDP
+    min: 7200
 
 - type: job
   id: Borg
@@ -23,3 +26,6 @@
   supervisors: job-supervisors-rd
   jobEntity: PlayerBorgBattery
   canHavePassport: false
+  requirements:
+  - !type:CharacterOverallTimeRequirement # WWDP
+    min: 3600

--- a/Resources/Prototypes/Roles/Jobs/Science/roboticist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/roboticist.yml
@@ -3,10 +3,11 @@
   name: job-name-roboticist
   description: job-description-roboticist
   playTimeTracker: JobRoboticist
+  setPreference: false # WWDP disabled role, not mapped
   requirements:
-  - !type:CharacterDepartmentTimeRequirement
-    department: Epistemics
-    min: 14400 # 4 hours - same as scientist
+  # - !type:CharacterDepartmentTimeRequirement # WWDP
+  #   department: Epistemics
+  #   min: 14400 # 4 hours - same as scientist
   - !type:CharacterEmployerRequirement
       employers:
       - ZavodskoiInterstellar

--- a/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
@@ -4,9 +4,9 @@
   description: job-description-scientist
   playTimeTracker: JobScientist
   requirements:
-    - !type:CharacterDepartmentTimeRequirement
-      department: Epistemics # DeltaV - Epistemics Department replacing Science
-      min: 14400 #4 hrs
+    # - !type:CharacterDepartmentTimeRequirement # WWDP
+    #   department: Epistemics # DeltaV - Epistemics Department replacing Science
+    #   min: 14400 #4 hrs
     - !type:CharacterEmployerRequirement
       employers:
       - NanoTrasen

--- a/Resources/Prototypes/Roles/Jobs/Science/senior_researcher.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/senior_researcher.yml
@@ -3,10 +3,11 @@
   name: job-name-senior-researcher
   description: job-description-senior-researcher
   playTimeTracker: JobSeniorResearcher
+  setPreference: false # WWDP disabled role, not mapped
   requirements:
-    - !type:CharacterDepartmentTimeRequirement
-      department: Epistemics # DeltaV - Epistemics Department replacing Science
-      min: 216000 #60 hrs
+    # - !type:CharacterDepartmentTimeRequirement # WWDP
+    #   department: Epistemics # DeltaV - Epistemics Department replacing Science
+    #   min: 216000 #60 hrs
     - !type:CharacterEmployerRequirement
       employers:
       - NanoTrasen

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -4,9 +4,9 @@
   description: job-description-detective
   playTimeTracker: JobDetective
   requirements:
-  - !type:CharacterDepartmentTimeRequirement
-    department: Security
-    min: 36000 # DeltaV - 10 hours
+  # - !type:CharacterDepartmentTimeRequirement # WWDP
+  #   department: Security
+  #   min: 36000 # DeltaV - 10 hours
   - !type:CharacterTraitRequirement
     inverted: true
     traits:

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -4,9 +4,9 @@
   description: job-description-security
   playTimeTracker: JobSecurityOfficer
   requirements:
-    - !type:CharacterDepartmentTimeRequirement
-      department: Security
-      min: 36000 # 10 hours
+    # - !type:CharacterDepartmentTimeRequirement # WWDP
+    #   department: Security
+    #   min: 36000 # 10 hours
     - !type:CharacterTraitRequirement
       inverted: true
       traits:

--- a/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
@@ -3,20 +3,20 @@
   name: job-name-senior-officer
   description: job-description-senior-officer
   playTimeTracker: JobSeniorOfficer
-  setPreference: true
+  setPreference: false # WWDP disabled role, not mapped
   requirements:
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobWarden
-      min: 21600 #6 hrs
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobDetective
-      min: 7200 #2 hrs
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobSecurityOfficer
-      min: 21600 #6 hrs
-    - !type:CharacterDepartmentTimeRequirement
-      department: Security
-      min: 216000 # 60 hrs
+    # - !type:CharacterPlaytimeRequirement # WWDP
+    #   tracker: JobWarden
+    #   min: 21600 #6 hrs
+    # - !type:CharacterPlaytimeRequirement
+    #   tracker: JobDetective
+    #   min: 7200 #2 hrs
+    # - !type:CharacterPlaytimeRequirement
+    #   tracker: JobSecurityOfficer
+    #   min: 21600 #6 hrs
+    # - !type:CharacterDepartmentTimeRequirement
+    #   department: Security
+    #   min: 216000 # 60 hrs
     - !type:CharacterTraitRequirement
       inverted: true
       traits:

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -4,12 +4,13 @@
   description: job-description-warden
   playTimeTracker: JobWarden
   requirements:
-    - !type:CharacterPlaytimeRequirement # DeltaV - JobSecurityOfficer time requirement. Make them experienced in proper officer work.
-      tracker: JobSecurityOfficer
-      min: 43200 # DeltaV - 12 hrs
-    - !type:CharacterPlaytimeRequirement # DeltaV - JobDetective time requirement. Give them an understanding of basic forensics.
-      tracker: JobDetective
-      min: 14400 # DeltaV - 4 hours
+    # WWDP disabled trackers
+    # - !type:CharacterPlaytimeRequirement # DeltaV - JobSecurityOfficer time requirement. Make them experienced in proper officer work.
+    #   tracker: JobSecurityOfficer
+    #   min: 43200 # DeltaV - 12 hrs
+    # - !type:CharacterPlaytimeRequirement # DeltaV - JobDetective time requirement. Give them an understanding of basic forensics.
+    #   tracker: JobDetective
+    #   min: 14400 # DeltaV - 4 hours
     - !type:CharacterWhitelistRequirement
     - !type:CharacterTraitRequirement
       inverted: true

--- a/Resources/Prototypes/_White/Roles/Jobs/Civilian/hobo.yml
+++ b/Resources/Prototypes/_White/Roles/Jobs/Civilian/hobo.yml
@@ -4,9 +4,9 @@
   description: job-description-hobo
   playTimeTracker: JobHobo
   requirements:
-  - !type:CharacterDepartmentTimeRequirement
-    department: Civilian
-    min: 72000 # 20 ch
+  # - !type:CharacterDepartmentTimeRequirement
+  #   department: Civilian
+  #   min: 72000 # 20 ch
   - !type:CharacterSpeciesRequirement
     species:
     - Human

--- a/Resources/Prototypes/_White/Roles/Jobs/Command/maid.yml
+++ b/Resources/Prototypes/_White/Roles/Jobs/Command/maid.yml
@@ -5,12 +5,12 @@
   description: job-description-maid
   playTimeTracker: JobMaid
   requirements:
-  - !type:CharacterDepartmentTimeRequirement
-    department: Medical
-    min: 72000 # 20 ch
-  - !type:CharacterDepartmentTimeRequirement
-    department: Command
-    min: 72000 # 20 ch
+  #- !type:CharacterDepartmentTimeRequirement
+  #  department: Medical
+  #  min: 72000 # 20 ch
+  #- !type:CharacterDepartmentTimeRequirement
+  #  department: Command
+  #  min: 72000 # 20 ch
   - !type:CharacterOverallTimeRequirement
     min: 7200
   - !type:CharacterSpeciesRequirement
@@ -33,6 +33,7 @@
   - Command
   - Janitor
   - Kitchen # woman
+  - Service
   - Maintenance
   - BlueshieldOfficer
   - CentralCommand # Station NTR office


### PR DESCRIPTION
Скитузеру: убери из сервер конфига `game.role_timers = false`

:cl: vanx
- tweak: Исправлены таймеры ролей, СБ, инженеры и борги (кроме ролей новичков) открываются спустя час игры, главы и ИИ - через 2 часа.
- remove: Из меню создания персонажа убраны неактуальные роли, которых нет на картах.
