### PR TITLE
Minor psionics changes

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
+++ b/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
@@ -72,8 +72,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: StationEvent
-      weight: 40 # Guaranteed to happen every once in a while, but with intervals between incidents
-		 # wwdp 25 --> 40
+      weight: 40 #wwdp 25 --> 40
       reoccurrenceDelay: 30 #wwdp 15 --> 30
       earliestStart: 15 #wwdp edit
     - type: GlimmerEvent

--- a/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
+++ b/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
@@ -72,8 +72,10 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: StationEvent
-      weight: 25 # Guaranteed to happen every once in a while, but with intervals between incidents
-      reoccurrenceDelay: 15
+      weight: 40 # Guaranteed to happen every once in a while, but with intervals between incidents
+		 # wwdp 25 --> 40
+      reoccurrenceDelay: 30 #wwdp 15 --> 30
+      earliestStart: 15 #wwdp edit
     - type: GlimmerEvent
     - type: NoosphericZapRule
 
@@ -179,7 +181,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: GlimmerEvent
-    minimumGlimmer: 700
+    minimumGlimmer: 600 #wwdp 700 --> 600
     maximumGlimmer: 900
     glimmerBurnLower: 50
     glimmerBurnUpper: 250

--- a/Resources/Prototypes/Psionics/psionics.yml
+++ b/Resources/Prototypes/Psionics/psionics.yml
@@ -173,7 +173,7 @@
       dampeningModifier: 0.5
     - !type:PsionicAddAvailablePowers
       powerPrototype: AssayPower
-      weight: 0.1
+      weight: 1 #wwdp 0.1 --> 1
   removalFunctions:
     - !type:RemovePsionicActions
     - !type:RemovePsionicPowerComponents
@@ -338,10 +338,10 @@
       assayFeedback: telepathy-power-metapsionic-feedback
     - !type:PsionicAddAvailablePowers
       powerPrototype: XenoglossyPower
-      weight: 2
+      weight: 1 #wwdp 2 --> 1
     - !type:PsionicAddAvailablePowers
       powerPrototype: PsychognomyPower
-      weight: 0.1
+      weight: 1 #wwdp 0.1 --> 1
   removalFunctions:
     - !type:RemovePsionicPowerComponents
       components:
@@ -503,7 +503,7 @@
       psychognomicDescriptor: tenebrous
     - !type:PsionicAddAvailablePowers
       powerPrototype: DarkSwapPower
-      weight: 1
+      weight: 1.5 #wwdp 1 --> 1.5
   removalFunctions:
     - !type:RemovePsionicActions
     - !type:RemovePsionicStatSources


### PR DESCRIPTION
# Описание PR

Теперь казино в псионике окупается
Ноосферный разряд ВРОДЕ КАК должен происходить чаще, но я не разбираюсь в этой штуке хелп

# Изменения

:cl:
- tweak: Событие Ноосферный разряд стало происходить чаще
- tweak: Шансы на получение улучшенной псионической способности стали лучше
- tweak: Минимум мерцания для появления ноосферных клещей уменьшено. 700 --> 600