### PR TITLE
[FIX] Шлюзы, Кустик, Точки телепортации

### DIFF
--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.Ghost.Components;
 using Content.Server.Mind;
 using Content.Server.Roles.Jobs;
 using Content.Server.Warps;
+using Content.Shared.Ninja.Components;
 using Content.Shared.Actions;
 using Content.Shared.CCVar;
 using Content.Shared.Damage;
@@ -342,6 +343,10 @@ namespace Content.Server.Ghost
 
             while (allQuery.MoveNext(out var uid, out var warp))
             {
+                // WWDP: Skip warp points that are bombing targets for ninja
+                if (HasComp<BombingTargetComponent>(uid))
+                    continue;
+
                 yield return new GhostWarp(GetNetEntity(uid), warp.Location ?? Name(uid), true);
             }
         }

--- a/Content.Server/Store/Systems/StoreSystem.Refund.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Refund.cs
@@ -24,7 +24,7 @@ public sealed partial class StoreSystem
 
     private void OnEntityInserted(EntityUid uid, StoreRefundComponent component, EntInsertedIntoContainerMessage args)
     {
-        if (component.StoreEntity == null || _actions.TryGetActionData(uid, out _) || !TryComp<StoreComponent>(component.StoreEntity.Value, out var storeComp))
+        if (component.StoreEntity == null || _actions.TryGetActionData(uid, out _, false) || !TryComp<StoreComponent>(component.StoreEntity.Value, out var storeComp)) // WWDP fix, add "false"
             return;
 
         DisableRefund(component.StoreEntity.Value, storeComp);

--- a/Content.Server/_Goobstation/Teleportation/Systems/PocketDimensionSystem.cs
+++ b/Content.Server/_Goobstation/Teleportation/Systems/PocketDimensionSystem.cs
@@ -19,6 +19,7 @@ public sealed class PocketDimensionSystem : EntitySystem
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly LinkedEntitySystem _link = default!;
     [Dependency] private readonly MapLoaderSystem _mapLoader = default!;
+    [Dependency] private readonly SharedMapSystem _mapSystem = default!; // WWDP fix
 
     private ISawmill _sawmill = default!;
 
@@ -65,6 +66,16 @@ public sealed class PocketDimensionSystem : EntitySystem
             }
 
             comp.PocketDimensionMap = map;
+
+        // WWDP edit start
+            // Ensure the pocket dimension map is properly initialized to prevent infinite state bug
+            var mapId = Comp<MapComponent>(map.Value).MapId;
+            if (!_mapSystem.IsInitialized(mapId))
+            {
+                _mapSystem.InitializeMap(mapId);
+                _sawmill.Info($"Initialized pocket dimension map {mapId}");
+            }
+        // WWDP edit end
 
             // find the pocket dimension's first grid and put the portal there
             bool foundGrid = false;

--- a/Content.Shared/Doors/Components/AirlockComponent.cs
+++ b/Content.Shared/Doors/Components/AirlockComponent.cs
@@ -158,5 +158,11 @@ public sealed partial class AirlockComponent : Component
     [DataField]
     public float BoltedPryModifier = 3f;
 
+    /// <summary>
+    /// WWDP FIX
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool OpenedMechanically = false; 
+
     #endregion Graphics
 }

--- a/Resources/Locale/ru-RU/storage/components/secret-stash-component.ftl
+++ b/Resources/Locale/ru-RU/storage/components/secret-stash-component.ftl
@@ -3,7 +3,7 @@
 comp-secret-stash-secret-part-name = { $name }
 comp-secret-stash-action-hide-success = Вы спрятали { $item } в { $this }
 comp-secret-stash-action-hide-container-not-empty = Здесь уже что-то есть?!
-comp-secret-stash-action-hide-item-too-big = { $item } слишком большой, чтобы поместиться в { $stash }!
-comp-secret-stash-action-get-item-found-something = Внутри { $stash } что-то было!
+comp-secret-stash-action-hide-item-too-big = { $item } слишком большой, чтобы поместиться в { $stashname }!
+comp-secret-stash-action-get-item-found-something = Внутри { $stashname } что-то было!
 secret-stash-part-plant = растение
 secret-stash-part-toilet = бачок унитаза


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

https://github.com/WWhiteDreamProject/wwdpublic/issues/714
https://github.com/WWhiteDreamProject/wwdpublic/issues/713

Плюсом убрал из точек телепортации BombingTarget, потому что, а нахуя они там? 

---


# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl:
- tweak: Точки телепортации призрака больше не включают BombingTarget
- fix: Обесточенные двери теперь возможно закрыть
- fix: Кустовое пространство инитнуто, и в общем фикс ошибок связанных с ним 