### PR TITLE
[Fix] Выключение зернистости при включённом режиме совместимости

### DIFF
--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -1,5 +1,6 @@
 using Content.Client._White.ItemSlotRenderer;
 using Content.Client._White.Overlays;
+using Content.Shared._White.CCVar;
 using Content.Client.Administration.Managers;
 using Content.Client.Changelog;
 using Content.Client.Chat.Managers;
@@ -167,6 +168,7 @@ namespace Content.Client.Entry
             _overlayManager.AddOverlay(new SingularityOverlay());
             _overlayManager.AddOverlay(new RadiationPulseOverlay());
             _overlayManager.AddOverlay(new GrainOverlay()); // WD EDIT
+            if(_configManager.GetCVar(CVars.DisplayCompat)) _configManager.SetCVar(WhiteCVars.FilmGrain, false); // WD EDIT
             _overlayManager.AddOverlay(new SpriteToLayerBullshitOverlay()); // WD EDIT
             _chatManager.Initialize();
             _clientPreferencesManager.Initialize();

--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -168,7 +168,7 @@ namespace Content.Client.Entry
             _overlayManager.AddOverlay(new SingularityOverlay());
             _overlayManager.AddOverlay(new RadiationPulseOverlay());
             _overlayManager.AddOverlay(new GrainOverlay()); // WD EDIT
-            if(_configManager.GetCVar(CVars.DisplayCompat)) _configManager.SetCVar(WhiteCVars.FilmGrain, false); // WD EDIT
+            if (_configManager.GetCVar(CVars.DisplayCompat)) _configManager.SetCVar(WhiteCVars.FilmGrain, false); // WD EDIT
             _overlayManager.AddOverlay(new SpriteToLayerBullshitOverlay()); // WD EDIT
             _chatManager.Initialize();
             _clientPreferencesManager.Initialize();


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

Добавил проверку на режим совместимости, если включен то выключается зернистость и всё, потому что весь экран становится белым и может отпугнуть некоторых игроков

---

# Медиа

<!--
Сюда можно вставить различные видео или скриншоты, необходимые для демонстрации работоспособности пулл реквеста.
Если в этом нет необходимости, то весь пункт можно просто удалить.
-->

<details><summary>Список</summary>
<p>

<img width="1668" height="1135" alt="изображение" src="https://github.com/user-attachments/assets/f41bed37-79a2-44fc-91d6-8385464d7247" />

</p>
</details>

---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl:
- fix: Зернистость сама отключается при включённом режиме совместимости
