### PR TITLE
Еще одна порция фиксов динамика

### DIFF
--- a/Content.Server/GameTicking/Rules/DynamicRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/DynamicRuleSystem.cs
@@ -22,7 +22,7 @@ public sealed class DynamicRuleSystem : GameRuleSystem<DynamicRuleComponent>
     {
         base.Added(uid, component, gameRule, args);
 
-        component.Budget = _random.Next(component.StartingBudgetMin, component.StartingBudgetMax);;
+        component.Budget = _random.Next(component.StartingBudgetMin, component.StartingBudgetMax);
         component.NextRuleTime = Timing.CurTime + _random.Next(component.MinRuleInterval, component.MaxRuleInterval);
     }
 

--- a/Content.Server/GameTicking/Rules/DynamicRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/DynamicRuleSystem.cs
@@ -33,7 +33,7 @@ public sealed class DynamicRuleSystem : GameRuleSystem<DynamicRuleComponent>
         // Since we don't know how long until this rule is activated, we need to
         // set the last budget update to now so it doesn't immediately give the component a bunch of points.
         component.LastBudgetUpdate = Timing.CurTime;
-        Execute((uid, component));
+        StartSelection((uid, component));
     }
 
     protected override void Ended(EntityUid uid, DynamicRuleComponent component, GameRuleComponent gameRule, GameRuleEndedEvent args)
@@ -121,6 +121,20 @@ public sealed class DynamicRuleSystem : GameRuleSystem<DynamicRuleComponent>
         entity.Comp.Rules.AddRange(executedRules);
         return executedRules;
     }
+
+    // WD edit start
+    private void StartSelection(Entity<DynamicRuleComponent> entity)
+    {
+        entity.Comp.Budget /= 2;
+        var roundstartBudget = entity.Comp.Budget;
+
+        var executedRules = Execute(entity);
+        while (executedRules.Count != 0)
+            executedRules = Execute(entity);
+
+        entity.Comp.Budget += roundstartBudget;
+    }
+    // WD edit end
 
     #region Command Methods
 

--- a/Resources/Prototypes/DeltaV/GameRules/midround.yml
+++ b/Resources/Prototypes/DeltaV/GameRules/midround.yml
@@ -10,4 +10,4 @@
     - ParadoxAnomalyFriendObjective
     - ParadoxAnomalyEscapeObjective
   - type: DynamicRuleCost # WD edit
-    cost: 4
+    cost: 8

--- a/Resources/Prototypes/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/GameRules/dynamic_rules.yml
@@ -16,7 +16,7 @@
       - !type:GroupSelector
         conditions:
         - !type:RoundDurationCondition
-          max: 1
+          max: 120 # WD edit 1 -> 120, because of lags rounds don't start immediately.
         children:
         - id: Traitor
           weight: 34
@@ -76,7 +76,7 @@
       - !type:GroupSelector
         conditions:
         - !type:RoundDurationCondition
-          max: 1
+          max: 120 # WD edit 1 -> 120, because of lags rounds don't start immediately.
         children:
 #        - id: Thief
 #          prob: 0.5
@@ -110,6 +110,8 @@
           - !type:MaxRuleOccurenceCondition
           - !type:RoundDurationCondition
             min: 900 # 15 minutes
+          - !type:PlayerCountCondition # WD edit
+            min: 29
         - id: NinjaSpawn
           weight: 20
           conditions:
@@ -117,6 +119,8 @@
           - !type:MaxRuleOccurenceCondition
           - !type:RoundDurationCondition
             min: 900 # 15 minutes
+          - !type:PlayerCountCondition # WD edit
+            min: 30
         - id: ParadoxAnomalySpawn # WD edit
           weight: 25
           conditions:

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -194,7 +194,7 @@
       mindRoles:
       - MindRoleDragon
   - type: DynamicRuleCost
-    cost: 4 # WD edit: 75 -> 4
+    cost: 10 # WD edit: 75 -> 10
 
 - type: entity
   parent: BaseGameRule
@@ -244,7 +244,7 @@
       mindRoles:
       - MindRoleNinja
   - type: DynamicRuleCost
-    cost: 8 # WD edit: 75 -> 8
+    cost: 15 # WD edit: 75 -> 8
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -244,7 +244,7 @@
       mindRoles:
       - MindRoleNinja
   - type: DynamicRuleCost
-    cost: 15 # WD edit: 75 -> 8
+    cost: 15 # WD edit: 75 -> 15
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/_Shitmed/GameRules/events.yml
+++ b/Resources/Prototypes/_Shitmed/GameRules/events.yml
@@ -73,7 +73,7 @@
       mindRoles:
       - MindRoleLoneAbductor
   - type: DynamicRuleCost # WD edit
-    cost: 8
+    cost: 15
 
 - type: entity
   parent: BaseGameRule
@@ -221,4 +221,4 @@
       mindRoles:
       - MindRoleLoneAbductor
   - type: DynamicRuleCost # WD edit
-    cost: 8
+    cost: 16


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

Я написал свой метод распределения раундстартого бюджета, потому что у виздена... ЕГО НЕ БЫЛО. Смысл динамика в том, что он multiantag, при этом по их системе раундстартом спавнился всего один антаг. Хотя на самом деле они вообще не спавнились, потому что один из кондишенов для их спавна говорил им делать это до первой секунды запуска раунда, что невозможно из-за лагов.

Также были повышены цены некоторых ивентов. Отслеживать их можно здесь https://docs.google.com/spreadsheets/d/1_4ljuwgtKZTycCTxwcS8WFzesJgKfEQ52eNuEyi44K4/edit?usp=sharing
# Изменения

:cl:
- tweak: Повышены цены некоторых антагов в динамике. Их все также можно отслеживать в документе, ссылка на который приложена в PR.
- tweak: Добавлен минимальный порог игроков для спавна ниндзи и дракона.
- fix: Исправлен раундстартовый спавн антагов в динамике. 
