### PR TITLE
[Fix] Wonder Box Test Fail

### DIFF
--- a/Content.Server/Decals/DecalSystem.cs
+++ b/Content.Server/Decals/DecalSystem.cs
@@ -296,7 +296,10 @@ namespace Content.Server.Decals
             decalId = 0;
 
             if (!PrototypeManager.HasIndex<DecalPrototype>(decal.Id))
+            {
+                Log.Error($"Decal with id: {decal.Id} does not exist!"); // WD EDIT
                 return false;
+            }
 
             var gridId = coordinates.GetGridUid(EntityManager);
             if (!TryComp(gridId, out MapGridComponent? grid))

--- a/Content.Server/Procedural/DungeonSystem.Rooms.cs
+++ b/Content.Server/Procedural/DungeonSystem.Rooms.cs
@@ -258,10 +258,8 @@ public sealed partial class DungeonSystem
                 // Offset by 0.5 because decals are offset from bot-left corner
                 // So we convert it to center of tile then convert it back again after transform.
                 // Do these shenanigans because 32x32 decals assume as they are centered on bottom-left of tiles.
-                // WD EDIT START
-                var position = Vector2.Transform(decal.Coordinates + Vector2Helpers.Half - roomCenter, roomTransform);
-                position -= Vector2Helpers.Half;
-                // WD EDIT END
+                var position = Vector2.Transform(decal.Coordinates + grid.TileSizeHalfVector - roomCenter, roomTransform);
+                position -= grid.TileSizeHalfVector;
 
                 if (!clearExisting && reservedTiles?.Contains(position.Floored()) == true)
                     continue;

--- a/Resources/Maps/_White/Atlases/WonderBoxMaint.yml
+++ b/Resources/Maps/_White/Atlases/WonderBoxMaint.yml
@@ -3567,13 +3567,13 @@ entities:
             1052: 27,263
         - node:
             color: '#FFFFFFFF'
-            id: WindowFrameEndN
+            id: WindowFrameWhiteEndN
           decals:
             952: 12,236
             953: 14,235
         - node:
             color: '#FFFFFFFF'
-            id: WindowFrameEndS
+            id: WindowFrameWhiteEndS
           decals:
             954: 14,234
             955: 12,235


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

Я наконец то разобрался с причиной по которой вондер бокс время от времени ломал тесты. На атласе было 2 несуществующих декаля. Во избежание повтора добавил логирование при попытке добавить несуществующий декаль.


---


# Изменения

no cl 
