### PR TITLE
[feature] Создание списка покупок для финального окна раунда

### DIFF
--- a/Content.Server/Mind/PurchasesListSystem.cs
+++ b/Content.Server/Mind/PurchasesListSystem.cs
@@ -1,0 +1,49 @@
+using Content.Shared.FixedPoint;
+using Content.Shared.Mind.Components;
+using Content.Shared.Store;
+using Robust.Shared.Prototypes;
+using Content.Server.StoreDiscount.Systems;
+
+namespace Content.Server.Mind;
+
+public sealed class PurchasesListSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<StoreBuyFinishedEvent>(
+            OnStoreBuyFinished,
+            before: new[] { typeof(StoreDiscountSystem) }
+        );
+    }
+
+    private void OnStoreBuyFinished(ref StoreBuyFinishedEvent ev)
+    {
+        if (!TryComp<MindContainerComponent>(ev.Buyer, out var mindContainer))
+            return;
+
+        if (mindContainer.Mind is null)
+            return;
+
+        var mind = mindContainer.Mind.Value;
+
+        if (!TryComp<PurchasesListComponent>(mind, out var purchases))
+            purchases = AddComp<PurchasesListComponent>(mind);
+
+        var listing = ev.PurchasedItem;
+
+        var originalCost = new Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2>(listing.OriginalCost);
+        var cost = new Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2>(listing.Cost);
+
+        var record = new PurchasedItemRecord(
+            name: listing.Name,
+            originalCost: originalCost,
+            cost: cost
+        );
+
+        purchases.PurchaseHistory.Add(record);
+
+        Dirty(mind, purchases);
+    }
+}

--- a/Content.Shared/Mind/Components/PurchasesListComponent.cs
+++ b/Content.Shared/Mind/Components/PurchasesListComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+using Content.Shared.Store;
+
+namespace Content.Shared.Mind.Components;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class PurchasesListComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public List<PurchasedItemRecord> PurchaseHistory { get; set; } = new();
+}

--- a/Content.Shared/Store/PurchasedItemRecord.cs
+++ b/Content.Shared/Store/PurchasedItemRecord.cs
@@ -1,0 +1,33 @@
+using Content.Shared.FixedPoint;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Store;
+
+[Serializable, NetSerializable]
+public sealed class PurchasedItemRecord
+{
+    [DataField]
+    public string? Name;
+
+    [DataField]
+    public Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2> OriginalCost =
+        new();
+
+    [DataField]
+    public Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2> Cost =
+        new();
+
+    public PurchasedItemRecord() { }
+
+    public PurchasedItemRecord(
+        string? name,
+        Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2> originalCost,
+        Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2> cost
+        )
+    {
+        Name = name;
+        OriginalCost = originalCost;
+        Cost = cost;
+    }
+}


### PR DESCRIPTION
# Описание PR

Нейрокод, который при покупке добавляет компонент PurchasesListComponent в сущность Mind, если такого не было. Затем добавляет в список словарь с именем купленного листинга, цену купленного листинга (Словарь валюта и цена), цену с учётом скидки (тоже словарь). На данный момент не учитывает возвраты. Позже можно будет вывести его в окне информации о раунде.

#### Словарь имеет три переменных:

Не пиздите ногами. Задача оказалась в моей зоне актуального развития. 