### PR TITLE
'EvacPod' game fix

### DIFF
--- a/Content.Client/_EstacaoPirata/Cards/CardSpriteSystem.cs
+++ b/Content.Client/_EstacaoPirata/Cards/CardSpriteSystem.cs
@@ -66,6 +66,7 @@ public sealed class CardSpriteSystem : EntitySystem
             var (cardIndex, layer) = obj;
             sprite.LayerSetVisible(j, true);
             sprite.LayerSetRSI(j, layer.Rsi); // WWDP EDIT
+            sprite.LayerSetTexture(j, layer.Texture);
             sprite.LayerSetState(j, layer.RsiState.Name);
             layerFunc.Invoke((uid, sprite), cardIndex, j);
             j++;


### PR DESCRIPTION
# Описание PR

Теперь нету ERROR'ок в спрайтах карточек, ура!

---

# Медиа

<details><summary>Скринчик</summary>
<p>

<img width="103" height="66" alt="image" src="https://github.com/user-attachments/assets/68d78a4f-5222-435a-8815-c4c378b75f9e" />

</p>
</details>

---

# Изменения

:cl: Spatison
- fix: Исправлено поведение карточек игры EvacPod при их совмещении.
