### PR TITLE
Мои тщетные попытки починить динамик

### DIFF
--- a/Content.Shared/EntityTable/Conditions/RoundDurationCondition.cs
+++ b/Content.Shared/EntityTable/Conditions/RoundDurationCondition.cs
@@ -13,7 +13,7 @@ public sealed partial class RoundDurationCondition : EntityTableCondition
     /// Minimum time the round must have gone on for this condition to pass.
     /// </summary>
     [DataField]
-    public TimeSpan Min = TimeSpan.Zero;
+    public TimeSpan Min = TimeSpan.MinValue; // WD edit
 
     /// <summary>
     /// Maximum amount of time the round could go on for this condition to pass.

--- a/Resources/Prototypes/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/GameRules/dynamic_rules.yml
@@ -16,7 +16,7 @@
       - !type:GroupSelector
         conditions:
         - !type:RoundDurationCondition
-          max: 120 # WD edit 1 -> 120, because of lags rounds don't start immediately.
+          max: 180 # WD edit 1 -> 180, because of lags rounds don't start immediately.
         children:
         - id: Traitor
           weight: 34
@@ -83,7 +83,7 @@
       - !type:GroupSelector
         conditions:
         - !type:RoundDurationCondition
-          max: 120 # WD edit 1 -> 120, because of lags rounds don't start immediately.
+          max: 180 # WD edit 1 -> 180, because of lags rounds don't start immediately.
         children:
 #        - id: Thief
 #          prob: 0.5


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

Сей прекрасный режим идеально работает у меня на локалке, но у него проблемы с выдачей раундстарт антагов на сервере. Появилась теория, что на сервере из-за лагов RoundDuration возвращает -1 при спавне геймрула динамика. Опять же, на локалке все работает отлично, я честно не знаю, что еще можно сделать

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->
