### PR TITLE
[Add] Chat Bubble Limit Cvars

### DIFF
--- a/Content.Client/Chat/UI/SpeechBubble.cs
+++ b/Content.Client/Chat/UI/SpeechBubble.cs
@@ -52,6 +52,12 @@ namespace Content.Client.Chat.UI
         /// </summary>
         public const float SpeechMaxWidth = 256;
 
+        /// <summary>
+        ///  White Dream;
+        ///  Max amount of characters in a speech bubble
+        /// </summary>
+        public int SingleBubbleCharLimit => ConfigManager.GetCVar(WhiteCVars.SingleBubbleCharLimit);
+
         private readonly EntityUid _senderEntity;
 
         private float _timeLeft = TotalTime;
@@ -222,6 +228,21 @@ namespace Content.Client.Chat.UI
             return FormatSpeech(SharedChatSystem.GetStringInsideTag(message, tag), fontColor);
         }
 
+        public ChatMessage TruncateWrappedMessage(ChatMessage message, int maxLength)
+        {
+            var text = SharedChatSystem.GetStringInsideTag(message, "BubbleContent");
+
+            if (text.Length <= maxLength)
+                return message;
+
+            text = text[..maxLength].TrimEnd(' ', '.', ',', ';', ':', '!', '?') + "...";
+
+            var newmsg = SharedChatSystem.SetStringInsideTag(message,"BubbleContent", text);
+
+            message.WrappedMessage = newmsg;
+
+            return message;
+        }
     }
 
     public sealed class TextSpeechBubble : SpeechBubble
@@ -237,6 +258,8 @@ namespace Content.Client.Chat.UI
             {
                 MaxWidth = SpeechMaxWidth,
             };
+
+            message = TruncateWrappedMessage(message, SingleBubbleCharLimit);  // White Dream
 
             label.SetMessage(FormatSpeech(message.WrappedMessage, fontColor, "Bedstead")); // WWDP EDIT
 
@@ -267,6 +290,8 @@ namespace Content.Client.Chat.UI
                 {
                     MaxWidth = SpeechMaxWidth
                 };
+
+                message = TruncateWrappedMessage(message, SingleBubbleCharLimit); // White Dream
 
                 label.SetMessage(FormatSpeech(SharedChatSystem.GetStringInsideTag(message, "BubbleContent"), fontColor, "Bedstead")); // WWDP EDIT // LESS USELESS ONE LINER FUNCS PLS
 

--- a/Content.Client/Chat/UI/SpeechBubble.cs
+++ b/Content.Client/Chat/UI/SpeechBubble.cs
@@ -56,7 +56,21 @@ namespace Content.Client.Chat.UI
         ///  White Dream;
         ///  Max amount of characters in a speech bubble
         /// </summary>
-        public int SingleBubbleCharLimit => ConfigManager.GetCVar(WhiteCVars.SingleBubbleCharLimit);
+        public int SingleBubbleCharLimit
+        {
+            get
+            {
+                var cvar = ConfigManager.GetCVar(WhiteCVars.SingleBubbleCharLimit);
+
+                if (cvar <= 0)
+                {
+                    Logger.Error("Local CVar chat.bubble_character_limit is set to 0 or lower");
+                    cvar = 1;
+                }
+
+                return cvar;
+            }
+        }
 
         private readonly EntityUid _senderEntity;
 
@@ -228,6 +242,7 @@ namespace Content.Client.Chat.UI
             return FormatSpeech(SharedChatSystem.GetStringInsideTag(message, tag), fontColor);
         }
 
+        // WWDP EDIT START
         public ChatMessage TruncateWrappedMessage(ChatMessage message, int maxLength)
         {
             var text = SharedChatSystem.GetStringInsideTag(message, "BubbleContent");
@@ -243,6 +258,7 @@ namespace Content.Client.Chat.UI
 
             return message;
         }
+        // WWDP EDIT END
     }
 
     public sealed class TextSpeechBubble : SpeechBubble
@@ -259,7 +275,7 @@ namespace Content.Client.Chat.UI
                 MaxWidth = SpeechMaxWidth,
             };
 
-            message = TruncateWrappedMessage(message, SingleBubbleCharLimit);  // White Dream
+            message = TruncateWrappedMessage(message, SingleBubbleCharLimit);  // WWDP edit
 
             label.SetMessage(FormatSpeech(message.WrappedMessage, fontColor, "Bedstead")); // WWDP EDIT
 
@@ -291,7 +307,7 @@ namespace Content.Client.Chat.UI
                     MaxWidth = SpeechMaxWidth
                 };
 
-                message = TruncateWrappedMessage(message, SingleBubbleCharLimit); // White Dream
+                message = TruncateWrappedMessage(message, SingleBubbleCharLimit); // WWDP edit
 
                 label.SetMessage(FormatSpeech(SharedChatSystem.GetStringInsideTag(message, "BubbleContent"), fontColor, "Bedstead")); // WWDP EDIT // LESS USELESS ONE LINER FUNCS PLS
 

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -462,8 +462,10 @@ public sealed class ChatUIController : UIController
         if (existing.Count > SpeechBubbleCap)
         {
             // Get the oldest to start fading fast.
-            var last = existing[0];
-            last.FadeNow();
+            // White Dream edit - Get all of the older ones
+            var lastBubbles = existing[..^SpeechBubbleCap];
+            foreach (var last in lastBubbles)
+                last.FadeNow();
         }
     }
 

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -15,6 +15,7 @@ using Content.Client.Stylesheets;
 using Content.Client.UserInterface.Screens;
 using Content.Client.UserInterface.Systems.Chat.Widgets;
 using Content.Client.UserInterface.Systems.Gameplay;
+using Content.Shared._White.CCVar;
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
 using Content.Shared.Chat;
@@ -107,7 +108,7 @@ public sealed class ChatUIController : UIController
     /// <summary>
     ///     The max amount of chars allowed to fit in a single speech bubble.
     /// </summary>
-    private const int SingleBubbleCharLimit = 100;
+    private int SingleBubbleCharLimit => _config.GetCVar(WhiteCVars.SingleBubbleCharLimit); // White Dream moved to WhiteCvars
 
     /// <summary>
     ///     Base queue delay each speech bubble has.
@@ -117,12 +118,12 @@ public sealed class ChatUIController : UIController
     /// <summary>
     ///     Factor multiplied by speech bubble char length to add to delay.
     /// </summary>
-    private const float BubbleDelayFactor = 0.8f / SingleBubbleCharLimit;
+    private const float BubbleDelayFactor =  0.8f / 100; // White Dream
 
     /// <summary>
     ///     The max amount of speech bubbles over a single entity at once.
     /// </summary>
-    private const int SpeechBubbleCap = 4;
+    private int SpeechBubbleCap => _config.GetCVar(WhiteCVars.SpeechBubbleCap); // White Dream moved to WhiteCvars
 
     private LayoutContainer _speechBubbleRoot = default!;
 

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -108,7 +108,7 @@ public sealed class ChatUIController : UIController
     /// <summary>
     ///     The max amount of chars allowed to fit in a single speech bubble.
     /// </summary>
-    private int SingleBubbleCharLimit => _config.GetCVar(WhiteCVars.SingleBubbleCharLimit); // White Dream moved to WhiteCvars
+    private int SingleBubbleCharLimit => _config.GetCVar(WhiteCVars.SingleBubbleCharLimit); // WWDP moved to WhiteCvars
 
     /// <summary>
     ///     Base queue delay each speech bubble has.
@@ -118,12 +118,28 @@ public sealed class ChatUIController : UIController
     /// <summary>
     ///     Factor multiplied by speech bubble char length to add to delay.
     /// </summary>
-    private const float BubbleDelayFactor =  0.8f / 100; // White Dream
+    private const float BubbleDelayFactor =  0.8f / 100; // WWDP edit
 
+    // WWDP edit start
     /// <summary>
     ///     The max amount of speech bubbles over a single entity at once.
     /// </summary>
-    private int SpeechBubbleCap => _config.GetCVar(WhiteCVars.SpeechBubbleCap); // White Dream moved to WhiteCvars
+    private int SpeechBubbleCap
+    {
+        get
+        {
+            var cvar = _config.GetCVar(WhiteCVars.SpeechBubbleCap);
+
+            if (cvar <= 0)
+            {
+                Logger.Error("Local CVar chat.bubble_max_count is set to 0 or lower");
+                cvar = 1;
+            }
+
+            return cvar;
+        }
+    }
+    // WWDP edit end
 
     private LayoutContainer _speechBubbleRoot = default!;
 
@@ -461,11 +477,12 @@ public sealed class ChatUIController : UIController
 
         if (existing.Count > SpeechBubbleCap)
         {
-            // Get the oldest to start fading fast.
-            // White Dream edit - Get all of the older ones
+            // WWDP edit start
+            // Get all of the older ones
             var lastBubbles = existing[..^SpeechBubbleCap];
             foreach (var last in lastBubbles)
                 last.FadeNow();
+            // WWDP edit end
         }
     }
 

--- a/Content.Server/_White/TTS/TTSSystem.cs
+++ b/Content.Server/_White/TTS/TTSSystem.cs
@@ -24,7 +24,7 @@ public sealed partial class TTSSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _xforms = default!;
     [Dependency] private readonly LanguageSystem _language = default!;
 
-    private const int MaxMessageChars = 100 * 2; // same as SingleBubbleCharLimit * 2
+    private int MaxMessageChars => _cfg.GetCVar(WhiteCVars.SingleBubbleCharLimit) * 2; // White dream moved to cvar
     private bool _isEnabled;
 
     public override void Initialize()

--- a/Content.Server/_White/TTS/TTSSystem.cs
+++ b/Content.Server/_White/TTS/TTSSystem.cs
@@ -24,7 +24,7 @@ public sealed partial class TTSSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _xforms = default!;
     [Dependency] private readonly LanguageSystem _language = default!;
 
-    private int MaxMessageChars => _cfg.GetCVar(WhiteCVars.SingleBubbleCharLimit) * 2; // White dream moved to cvar
+    private int MaxMessageChars => _cfg.GetCVar(WhiteCVars.SingleBubbleCharLimit) * 2;
     private bool _isEnabled;
 
     public override void Initialize()

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -359,6 +359,22 @@ public abstract class SharedChatSystem : EntitySystem
         return rawmsg.Substring(tagStart, tagEnd - tagStart);
     }
 
+    // White Dream edit start
+    // Returns a message with a string inside tag removed and replaced
+    public static string SetStringInsideTag(ChatMessage message, string tag, string strInsert)
+    {
+        var rawmsg = message.WrappedMessage;
+        var tagStart = rawmsg.IndexOf($"[{tag}]");
+        var tagEnd = rawmsg.IndexOf($"[/{tag}]");
+        if (tagStart < 0 || tagEnd < 0)
+            return rawmsg;
+        tagStart += tag.Length + 2;
+        rawmsg = rawmsg.Remove(tagStart, tagEnd - tagStart);
+        rawmsg = rawmsg.Insert(tagStart, $"{strInsert}");
+        return rawmsg;
+    }
+    // White Dream edit end
+
     // WD EDIT START - Moved from ClatUIController
     /// <summary>
     /// Returns the chat name color for a mob

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -359,7 +359,7 @@ public abstract class SharedChatSystem : EntitySystem
         return rawmsg.Substring(tagStart, tagEnd - tagStart);
     }
 
-    // White Dream edit start
+    // WWDP edit start
     // Returns a message with a string inside tag removed and replaced
     public static string SetStringInsideTag(ChatMessage message, string tag, string strInsert)
     {
@@ -373,7 +373,7 @@ public abstract class SharedChatSystem : EntitySystem
         rawmsg = rawmsg.Insert(tagStart, $"{strInsert}");
         return rawmsg;
     }
-    // White Dream edit end
+    // WWDP edit end
 
     // WD EDIT START - Moved from ClatUIController
     /// <summary>

--- a/Content.Shared/_White/CCVar/WhiteCVars.Chat.cs
+++ b/Content.Shared/_White/CCVar/WhiteCVars.Chat.cs
@@ -14,8 +14,8 @@ public sealed partial class WhiteCVars
         CVarDef.Create("chat.colored_bubble", true, CVar.CLIENTONLY | CVar.ARCHIVE);
 
     public static readonly CVarDef<int> SingleBubbleCharLimit =
-        CVarDef.Create("chat.bubble_character_limit", 43, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("chat.bubble_character_limit", 43, CVar.CLIENT | CVar.ARCHIVE);
 
     public static readonly CVarDef<int> SpeechBubbleCap =
-        CVarDef.Create("chat.bubble_max_count", 1, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("chat.bubble_max_count", 1, CVar.CLIENT | CVar.ARCHIVE);
 }

--- a/Content.Shared/_White/CCVar/WhiteCVars.Chat.cs
+++ b/Content.Shared/_White/CCVar/WhiteCVars.Chat.cs
@@ -12,4 +12,10 @@ public sealed partial class WhiteCVars
 
     public static readonly CVarDef<bool> ColoredBubbleChat =
         CVarDef.Create("chat.colored_bubble", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<int> SingleBubbleCharLimit =
+        CVarDef.Create("chat.bubble_character_limit", 43, CVar.SERVER | CVar.REPLICATED);
+
+    public static readonly CVarDef<int> SpeechBubbleCap =
+        CVarDef.Create("chat.bubble_max_count", 1, CVar.SERVER | CVar.REPLICATED);
 }


### PR DESCRIPTION
Добавлены цвары chat.bubble_character_limit и chat.bubble_max_count.

Для уменьшения засорения экрана им установлены пониженные значения: 43 символа (2 строки) и максимум 1 одновременно над головой космонавтика.

<img width="279" height="167" alt="изображение" src="https://github.com/user-attachments/assets/f2dfd218-907d-425c-9544-81c6409c0f9d" />
<img width="513" height="125" alt="изображение" src="https://github.com/user-attachments/assets/edd411ed-36cc-4172-8fb1-c2e5d6422bd3" />


:cl: vanx
- tweak: Облачка с текстом персонажей теперь ограничены по количеству символов. Теперь их не может быть больше одного одновременно.
