### PR TITLE
[Fix] Shove Breaking Grab

### DIFF
--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -96,6 +96,9 @@ namespace Content.Server.Hands.Systems
             if (args.Handled)
                 return;
 
+            if (!_random.Prob(args.DisarmProbability)) // WWDP shove, with a chance to disarm
+                return;
+
             // Break any pulls
             if (TryComp(uid, out PullerComponent? puller) && TryComp(puller.Pulling, out PullableComponent? pullable))
                 _pullingSystem.TryStopPull(puller.Pulling.Value, pullable, ignoreGrab: true); // Goobstation edit added check for grab
@@ -105,9 +108,6 @@ namespace Content.Server.Hands.Systems
             // WWDP edit start
             if (TryGetActiveItem((args.Target, component), out var item))
             {
-                if (!_random.Prob(args.DisarmProbability)) // WWDP shove
-                    return;
-
                 args.DisarmObject = item.Value;
 
                 if (args.PickupToHands)

--- a/Content.Shared/Movement/Pulling/Components/PullableComponent.cs
+++ b/Content.Shared/Movement/Pulling/Components/PullableComponent.cs
@@ -52,7 +52,7 @@ public sealed partial class PullableComponent : Component
 
     // WWDP edit start
     [AutoNetworkedField, DataField]
-    public TimeSpan EscapeAttemptCooldown = TimeSpan.FromSeconds(3); // In seconds
+    public TimeSpan EscapeAttemptCooldown = TimeSpan.FromSeconds(2); // In seconds
 
     [AutoNetworkedField]
     public bool DisplayedCooldownPopup = true;

--- a/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
+++ b/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
@@ -108,8 +108,8 @@ public sealed partial class PullerComponent : Component
     public Dictionary<GrabStage, float> EscapeChances = new()
     {
         { GrabStage.No, 1f },
-        { GrabStage.Soft, 1f }, // WD EDIT
-        { GrabStage.Hard, 0.5f }, // WD EDIT
+        { GrabStage.Soft, 0.5f }, // WD EDIT
+        { GrabStage.Hard, 0.3f }, // WD EDIT
         { GrabStage.Suffocate, 0.1f },
     };
 


### PR DESCRIPTION
:cl: vanx
- fix: Толчок теперь отменяет граб только при выпадении дизарма.
- tweak: Кулдаун освобождения из граба уменьшен 3 -> 2 секунды.
- tweak: Базовый шанс вырваться из лёгкого граба 100% -> 50%, из сильного 50% -> 30%.

