### PR TITLE
[TWEAK] Psionic power pool twik

### DIFF
--- a/Resources/Prototypes/Psionics/PsionicPowerPool.yml
+++ b/Resources/Prototypes/Psionics/PsionicPowerPool.yml
@@ -15,6 +15,12 @@
     TelekineticPulsePower: 1
     PyrokineticFlare: 1 # Leads to summon imp and pyrokenisis
     NoosphericZapPower: 1
+    AssayPower: 1
+    XenoglossyPower: 1
+    RevivifyPower: 1
+    DarkSwapPower: 1
+    SummonImpPower: 1
+    PyrokinesisPower: 1
     ClonePower: 1 #wwdp ability
     PolymorphPower: 1 #wwdp ability
 
@@ -28,6 +34,8 @@
     MassSleepPower: 1
     PsionicInvisibilityPower: 1
     MindSwapPower: 1
+    AssayPower: 1
+    XenoglossyPower: 1
 
 - type: weightedRandom # WWDP Edit All weights set to 1
   id: ElementalistPowerPool # Significantly slower power generation. No Telepathy.
@@ -38,5 +46,9 @@
     TelekineticPulsePower: 1
     PyrokineticFlare: 1
     NoosphericZapPower: 1
+    RevivifyPower: 1
+    DarkSwapPower: 1
+    SummonImpPower: 1
+    PyrokinesisPower: 1
     ClonePower: 1 #wwdp ability
     PolymorphPower: 1 #wwdp ability

--- a/Resources/Prototypes/Psionics/psionics.yml
+++ b/Resources/Prototypes/Psionics/psionics.yml
@@ -171,9 +171,6 @@
     - !type:AddPsionicStatSources
       amplificationModifier: 0.5
       dampeningModifier: 0.5
-    - !type:PsionicAddAvailablePowers
-      powerPrototype: AssayPower
-      weight: 1 #wwdp 0.1 --> 1
   removalFunctions:
     - !type:RemovePsionicActions
     - !type:RemovePsionicPowerComponents
@@ -182,8 +179,6 @@
     - !type:RemovePsionicStatSources
     - !type:RemoveAssayFeedback
       assayFeedback: metapsionic-power-metapsionic-feedback
-    - !type:PsionicRemoveAvailablePowers
-      powerPrototype: AssayPower
 
 - type: psionicPower
   id: PsionicRegenerationPower
@@ -339,12 +334,6 @@
       feedbackMessage: telepathy-power-initialization-feedback
     - !type:AddPsionicAssayFeedback
       assayFeedback: telepathy-power-metapsionic-feedback
-    - !type:PsionicAddAvailablePowers
-      powerPrototype: XenoglossyPower
-      weight: 1 #wwdp 2 --> 1
-    - !type:PsionicAddAvailablePowers
-      powerPrototype: PsychognomyPower
-      weight: 1 #wwdp 0.1 --> 1
   removalFunctions:
     - !type:RemovePsionicActions #WD EDIT
     - !type:RemovePsionicPowerComponents
@@ -352,10 +341,6 @@
         - type: Telepathy
     - !type:RemoveAssayFeedback
       assayFeedback: telepathy-power-metapsionic-feedback
-    - !type:PsionicRemoveAvailablePowers
-      powerPrototype: XenoglossyPower
-    - !type:PsionicRemoveAvailablePowers
-      powerPrototype: PsychognomyPower
   powerSlotCost: 0
 
 - type: psionicPower
@@ -378,16 +363,11 @@
     - !type:AddPsionicStatSources
       amplificationModifier: 1
       dampeningModifier: 0.5
-    - !type:PsionicAddAvailablePowers
-      powerPrototype: RevivifyPower
-      weight: 2
   removalFunctions:
     - !type:RemovePsionicActions
     - !type:RemovePsionicStatSources
     - !type:RemoveAssayFeedback
       assayFeedback: healing-word-power-metapsionic-feedback
-    - !type:PsionicRemoveAvailablePowers
-      powerPrototype: RevivifyPower
 
 - type: psionicPower
   id: RevivifyPower
@@ -505,9 +485,6 @@
       amplificationModifier: 1
     - !type:AddPsionicPsychognomicDescriptors
       psychognomicDescriptor: tenebrous
-    - !type:PsionicAddAvailablePowers
-      powerPrototype: DarkSwapPower
-      weight: 1
   removalFunctions:
     - !type:RemovePsionicActions
     - !type:RemovePsionicStatSources
@@ -515,8 +492,6 @@
       assayFeedback: shadeskip-power-metapsionic-feedback
     - !type:RemovePsionicPsychognomicDescriptors
       psychognomicDescriptor: tenebrous
-    - !type:PsionicRemoveAvailablePowers
-      powerPrototype: DarkSwapPower
 
 - type: psionicPower
   id: TelekineticPulsePower
@@ -599,12 +574,6 @@
       assayFeedback: pyrokinetic-flare-power-metapsionic-feedback
     - !type:AddPsionicStatSources
       amplificationModifier: 0.25
-    - !type:PsionicAddAvailablePowers
-      powerPrototype: SummonImpPower
-      weight: 1
-    - !type:PsionicAddAvailablePowers
-      powerPrototype: PyrokinesisPower
-      weight: 1
     - !type:AddPsionicPsychognomicDescriptors
       psychognomicDescriptor: pyre
   removalFunctions:
@@ -612,12 +581,6 @@
     - !type:RemovePsionicStatSources
     - !type:RemoveAssayFeedback
       assayFeedback: pyrokinetic-flare-power-metapsionic-feedback
-    - !type:PsionicRemoveAvailablePowers
-      powerPrototype: SummonImpPower
-    - !type:PsionicRemoveAvailablePowers
-      powerPrototype: PyrokinesisPower
-    - !type:RemovePsionicPsychognomicDescriptors
-      psychognomicDescriptor: pyre
   powerSlotCost: 1
 
 - type: psionicPower

--- a/Resources/Prototypes/Traits/Psionics/casterTypes.yml
+++ b/Resources/Prototypes/Traits/Psionics/casterTypes.yml
@@ -75,6 +75,7 @@
     - !type:TraitAddPsionics
       psionicPowers:
         - TelepathyPower
+        - PsychognomyPower #wwdp edit
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsCasterType


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

все способности находятся в прототипе паверпула, открывать их с помощью других способностей не нужно
это даст им шанс выпасть в раунде
а ещё бафнут психованный историк, у него будет психованный гномик

---

# Медиа

<!--
Сюда можно вставить различные видео или скриншоты, необходимые для демонстрации работоспособности пулл реквеста.
Если в этом нет необходимости, то весь пункт можно просто удалить.
-->

<details><summary>Список</summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl:
- tweak: Латентным псионикам увеличен список получаемых способностей
- add: Психоисторики сразу имеют психогномию
