### PR TITLE
Inhand Sprite Fallback

### DIFF
--- a/Content.Client/Items/Systems/ItemSystem.cs
+++ b/Content.Client/Items/Systems/ItemSystem.cs
@@ -100,8 +100,16 @@ public sealed class ItemSystem : SharedItemSystem
             ? defaultKey
             : $"{item.HeldPrefix}-{defaultKey}";
 
+        // WWDP edit start
+        // Fallback to defaultKey
         if (!rsi.TryGetState(state, out var _))
-            return false;
+        {
+            if (rsi.TryGetState(defaultKey, out var _))
+                state = defaultKey;
+            else
+                return false;
+        }
+        // WWDP edit end
 
         var layer = new PrototypeLayerData();
         layer.RsiPath = rsi.Path.ToString();


### PR DESCRIPTION
При отсутствии стейта спрайта в руке отрисовывается дефолтный.

Теперь при взятии двуручного оружия без двуручного спрайта отрисовывается спрайт для 1 руки.