### PR TITLE
слаймолюды должны страдать

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -85,7 +85,7 @@
         scaleByQuantity: true
         damage:
           types:
-            Heat: 0.15
+            Heat: 0.7 #WWDP
       - !type:PopupMessage
         type: Local
         messages: [ "slime-hurt-by-water-popup" ]

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -85,7 +85,7 @@
         scaleByQuantity: true
         damage:
           types:
-            Heat: 0.7 #WWDP
+            Heat: 0.7 #WD EDIT: 0.1 -> 0.7
       - !type:PopupMessage
         type: Local
         messages: [ "slime-hurt-by-water-popup" ]

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -98,14 +98,14 @@
         scaleByQuantity: true
         damage:
           types:
-            Heat: 0.7 #WWDP
+            Heat: 0.7 #WD EDIT: 0.1 -> 0.7
         conditions:
-        #WWDP EDIT START
+        #WD EDIT START
         - !type:HasComponentOnEquipmentCondition
           invert: true
           components:
           - type: PressureProtection
-        #WWDP EDIT END
+        #WD EDIT END
       - !type:PopupMessage
         type: Local
         visualType: Large

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -98,7 +98,7 @@
         scaleByQuantity: true
         damage:
           types:
-            Heat: 0.1
+            Heat: 0.7 #WWDP
       - !type:PopupMessage
         type: Local
         visualType: Large

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -99,6 +99,11 @@
         damage:
           types:
             Heat: 0.7 #WWDP
+        conditions:
+        - !type:HasComponentOnEquipmentCondition
+          invert: true
+          components:
+          - type: PressureProtection
       - !type:PopupMessage
         type: Local
         visualType: Large

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -100,10 +100,12 @@
           types:
             Heat: 0.7 #WWDP
         conditions:
+        #WWDP EDIT START
         - !type:HasComponentOnEquipmentCondition
           invert: true
           components:
           - type: PressureProtection
+        #WWDP EDIT END
       - !type:PopupMessage
         type: Local
         visualType: Large


### PR DESCRIPTION



<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

С какого то момента слаймы мобы и слаймолюди получали слишком мало урона от воды (0.15 слаймы мобы, и 0.1 слаймолюды). Изменил, теперь они обе получают по 0.7 урона.
Обливание огнетушителем вблизи наносит 13.84 урона. А 1 унция воды - 0.7.

---

# Медиа

<!--
Сюда можно вставить различные видео или скриншоты, необходимые для демонстрации работоспособности пулл реквеста.
Если в этом нет необходимости, то весь пункт можно просто удалить.
-->

<details><summary>Что здесь должно быть???</summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl:
- tweak: Изменен урон от воды у слаймов