### PR TITLE
Фикс бесконечного стамина крита

### DIFF
--- a/Content.Shared/Damage/Systems/StaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/StaminaSystem.cs
@@ -304,11 +304,11 @@ public sealed partial class StaminaSystem : EntitySystem
         RaiseLocalEvent(uid, ref ev);
         if (ev.Cancelled)
             return;
-        
+        //WWDP EDIT START
         if (component.Critical)
             return;
 
-
+        //WWDP EDIT END
         // Have we already reached the point of max stamina damage?
         if (component.Critical && immediate)
         {

--- a/Content.Shared/Damage/Systems/StaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/StaminaSystem.cs
@@ -304,6 +304,10 @@ public sealed partial class StaminaSystem : EntitySystem
         RaiseLocalEvent(uid, ref ev);
         if (ev.Cancelled)
             return;
+        
+        if (component.Critical)
+            return;
+
 
         // Have we already reached the point of max stamina damage?
         if (component.Critical && immediate)

--- a/Content.Shared/Damage/Systems/StaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/StaminaSystem.cs
@@ -304,11 +304,11 @@ public sealed partial class StaminaSystem : EntitySystem
         RaiseLocalEvent(uid, ref ev);
         if (ev.Cancelled)
             return;
-        //WWDP EDIT START
+        //WD EDIT START
         if (component.Critical)
             return;
 
-        //WWDP EDIT END
+        //WD EDIT END
         // Have we already reached the point of max stamina damage?
         if (component.Critical && immediate)
         {


### PR DESCRIPTION

<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

Есть баг бесконечного стамина крита. Суть в том что когда ты в стамина крите и ты получаешь урон по стамине, то игра считает что ты опять входишь в стамина крит. Починил, теперь система нанесения стамина урона смотрит в стамина крите ли существо, если да - отменяет урон по стамине.

---

# Медиа

<!--
Сюда можно вставить различные видео или скриншоты, необходимые для демонстрации работоспособности пулл реквеста.
Если в этом нет необходимости, то весь пункт можно просто удалить.
-->

<details><summary>Что здесь должно быть</summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl:
- fix: Исправлен бесконечный стамина крит
