### PR TITLE
Онлайн для динамика

### DIFF
--- a/Resources/Prototypes/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/GameRules/dynamic_rules.yml
@@ -128,14 +128,14 @@
             min: 900 # 15 minutes
           - !type:PlayerCountCondition # WD edit
             min: 15 # WD edit: 30 > 15
-        - id: ParadoxAnomalySpawn # WD edit
-          weight: 25
-          conditions:
-          - !type:HasBudgetCondition
-          - !type:MaxRuleOccurenceCondition
-            max: 2
-          - !type:RoundDurationCondition
-            min: 600 # 10 minutes
+      #- id: ParadoxAnomalySpawn # WD edit: turned off because it doesn't work
+      #   weight: 25
+      #   conditions:
+      #   - !type:HasBudgetCondition
+      #   - !type:MaxRuleOccurenceCondition
+      #     max: 2
+      #   - !type:RoundDurationCondition
+      #     min: 600 # 10 minutes
         - id: ZombieOutbreak
           weight: 2.5
           conditions:

--- a/Resources/Prototypes/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/GameRules/dynamic_rules.yml
@@ -41,7 +41,7 @@
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
           - !type:PlayerCountCondition
-            min: 20
+            min: 15 # WD edit: 20 > 15  
         # WD edit start
         - id: Changeling
           weight: 15
@@ -118,7 +118,7 @@
           - !type:RoundDurationCondition
             min: 900 # 15 minutes
           - !type:PlayerCountCondition # WD edit
-            min: 29
+            min: 20 # WD edit: 29 > 20
         - id: NinjaSpawn
           weight: 20
           conditions:
@@ -127,7 +127,7 @@
           - !type:RoundDurationCondition
             min: 900 # 15 minutes
           - !type:PlayerCountCondition # WD edit
-            min: 30
+            min: 15 # WD edit: 30 > 15
         - id: ParadoxAnomalySpawn # WD edit
           weight: 25
           conditions:
@@ -151,7 +151,7 @@
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
           - !type:PlayerCountCondition
-            min: 20
+            min: 15 # WD edit: 20 > 15  
           - !type:RoundDurationCondition
             min: 2100 # 35 minutes
         # WD edit start


### PR DESCRIPTION


<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

Из за слегка не достатка онлайна на некоторые геймрулов динамика, снизил им требования в онлайне
Зомби: 20 > 15
Дракон: 29 > 20
Ниндзя: 30 > 15
Одиночный Оперативник: 20 > 15
---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl:
- tweak: Изменены требования динамика к онлайну насчёт мидраунд ивентов