### PR TITLE
[TWEAK] Угол предметов в хранилищах (Сумки и подобное)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -63,6 +63,7 @@
       sprite: Objects/Specific/Medical/implanter.rsi
       heldPrefix: 0
       size: Small
+      storedRotation: 90 # WD ADD
     - type: Appearance
     - type: GenericVisualizer
       visuals:

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -32,6 +32,7 @@
     angle: 135
   - type: Item
     sprite: Objects/Tools/Hydroponics/hoe.rsi
+    storedRotation: 45 # WD ADD
   - type: EmitSoundOnPickup # White Dream
     sound:
       path: /Audio/SimpleStation14/Items/Handling/screwdriver_pickup.ogg
@@ -137,6 +138,11 @@
     angle: 315
   - type: Item
     size: Normal
+    # WD EDIT START
+    shape:
+    - 0,0,1,0
+    - 0,1,0,1
+    # WD EDIT END
   - type: Clothing
     sprite: Objects/Tools/Hydroponics/scythe.rsi
     slots:
@@ -192,6 +198,7 @@
   - type: EmbedPassiveDamage
   - type: Item
     sprite: Objects/Tools/Hydroponics/hatchet.rsi
+    storedRotation: 45 # WD ADD
   - type: Execution # WWDP
   # Shitmed Change
   - type: BoneSaw
@@ -243,6 +250,7 @@
     angle: 45
   - type: Item
     sprite: Objects/Tools/Hydroponics/spade.rsi
+    storedRotation: -45 # WD ADD
   - type: Shovel
     speedModifier: 0.85 # slower at digging than a full-sized shovel
   - type: EmitSoundOnPickup # White Dream

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -27,6 +27,7 @@
     state: ointment
   - type: Item
     heldPrefix: ointment
+    storedRotation: 45 # WD ADD
   - type: Healing
     damageContainers:
     - Biological
@@ -264,6 +265,10 @@
   id: Gauze
   suffix: Full
   components:
+  # WD EDIT START
+  - type: Item
+    storedRotation: 50
+  # WD EDIT END
   - type: Tag
     tags:
     - Gauze

--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -93,6 +93,11 @@
     sprite: Objects/Tanks/oxygen.rsi
   - type: Item
     sprite: Objects/Tanks/oxygen.rsi
+    # WD EDIT START
+    shape:
+    - 0,0,2,0
+    storedRotation: 44
+    # WD EDIT END
   - type: Clothing
     sprite: Objects/Tanks/oxygen.rsi
 
@@ -106,6 +111,11 @@
     sprite: Objects/Tanks/red.rsi
   - type: Item
     sprite: Objects/Tanks/red.rsi
+    # WD EDIT START
+    shape:
+    - 0,0,2,0
+    storedRotation: 44
+    # WD EDIT END
   - type: Clothing
     sprite: Objects/Tanks/red.rsi
 
@@ -313,6 +323,12 @@
   components:
   - type: GasTank
     outputPressure: 101.3
+  # WD EDIT START
+  - type: Item
+    shape:
+    - 0,0,2,0
+    storedRotation: 44
+  # WD EDIT END
 
 - type: entity
   parent: GasTankRoundBase
@@ -323,6 +339,11 @@
   - type: Sprite
     sprite: Objects/Tanks/anesthetic.rsi
   - type: Item
+    # WD EDIT START
+    shape:
+    - 0,0,2,0
+    storedRotation: 44
+    # WD EDIT END
     sprite: Objects/Tanks/anesthetic.rsi
   - type: GasTank
     outputPressure: 30.4

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -817,6 +817,11 @@
   - type: Item
     size: Normal
     sprite: Objects/Tools/shovel.rsi
+    # WD EDIT START
+    shape:
+    - 0,0,3,0
+    storedRotation: 44
+    # WD EDIT END
   - type: PhysicalComposition
     materialComposition:
       Steel: 100

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
@@ -81,6 +81,7 @@
     capacity: 35
   - type: Item
     size: Small
+    storedRotation: 45 # WD ADD
   - type: ContainerContainer
     containers:
       ballistic-ammo: !type:Container
@@ -102,6 +103,10 @@
   name: WT550 magazine (.35 auto top-mounted)
   parent: [ BaseItem, BaseSecurityContraband ]
   components:
+  # WD EDIT START
+  - type: Item
+    storedRotation: 90
+  # WD EDIT END
   - type: Tag
     tags:
     - MagazinePistolSubMachineGunTopMounted

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -433,7 +433,7 @@
     shape:
     - 0,0,3,0
     # WD EDIT END
-    storedRotation: 90
+    storedRotation: 180 #WD EDIT: 90 > 45
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/hm_pistol.rsi
   - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -433,7 +433,7 @@
     shape:
     - 0,0,3,0
     # WD EDIT END
-    storedRotation: 180 #WD EDIT: 90 > 45
+    storedRotation: 180 # WD EDIT: 90 > 180
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/hm_pistol.rsi
   - type: Clothing


### PR DESCRIPTION

# Описание PR


Ещё раз изменил угол предметов и их форму в хранилищах. Список изменённых форм:
Лопата: 2x2 > 1x4
Баллоны: 2x2 > 1x3
Коса ботаников: в форме L (Пистолета)
Остальные предметы лежат под правильным углом, то есть в которых их текстуры не выходят из их формы

---

# Медиа


<img width="215" height="273" alt="image" src="https://github.com/user-attachments/assets/9eee1194-b392-41b9-a583-63491a82c373" />


---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl:
- tweak: Изменены углы, формы того как лежат некоторые предметы в хранилищах