### PR TITLE
[TWEAK] Общесолнечный стоит теперь 2 очка, и доступен только дварфам и фелинидам

### DIFF
--- a/Resources/Prototypes/Traits/languages.yml
+++ b/Resources/Prototypes/Traits/languages.yml
@@ -18,31 +18,35 @@
       languagesUnderstood:
         - Sign
 
-# WD EDIT START
-#- type: trait
-#  id: SolCommon
-#  category: TraitsSpeechLanguages
-#  points: 0
-  # slots: 1
+- type: trait
+  id: SolCommon
+  category: TraitsSpeechLanguages
+  points: 2 # WD EDIT: 0 > 2
+  slots: 1 # WD EDIT: commented > slots 1
   # itemGroupSlots: 0
-#  requirements:
-  # - !type:CharacterItemGroupRequirement
-  #   group: TraitsLanguagesBasic
-#    - !type:CharacterSpeciesRequirement
-#      inverted: true
-#      species:
-#        - Human
-#    - !type:CharacterNationalityRequirement
-#      inverted: true
-#      nationalities:
-#        - Solarian
-#  functions:
-#    - !type:TraitModifyLanguages
-#      languagesSpoken:
-#        - SolCommon
-#      languagesUnderstood:
-#        - SolCommon
-# WD EDIT END: disabled so that non-humans cannot use it
+  requirements:
+    # - !type:CharacterItemGroupRequirement
+    #   group: TraitsLanguagesBasic
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Human
+    # WD EDIT START
+    - !type:CharacterSpeciesRequirement
+      species:
+        - Dwarf
+        - Felinid
+    # WD EDIT START: add
+    - !type:CharacterNationalityRequirement
+      inverted: true
+      nationalities:
+        - Solarian
+  functions:
+    - !type:TraitModifyLanguages
+      languagesSpoken:
+        - SolCommon
+      languagesUnderstood:
+        - SolCommon
 
 - type: trait
   id: Tradeband

--- a/Resources/Prototypes/Traits/languages.yml
+++ b/Resources/Prototypes/Traits/languages.yml
@@ -18,29 +18,31 @@
       languagesUnderstood:
         - Sign
 
-- type: trait
-  id: SolCommon
-  category: TraitsSpeechLanguages
-  points: 0
+# WD EDIT START
+#- type: trait
+#  id: SolCommon
+#  category: TraitsSpeechLanguages
+#  points: 0
   # slots: 1
   # itemGroupSlots: 0
-  requirements:
-    # - !type:CharacterItemGroupRequirement
-    #   group: TraitsLanguagesBasic
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Human
-    - !type:CharacterNationalityRequirement
-      inverted: true
-      nationalities:
-        - Solarian
-  functions:
-    - !type:TraitModifyLanguages
-      languagesSpoken:
-        - SolCommon
-      languagesUnderstood:
-        - SolCommon
+#  requirements:
+  # - !type:CharacterItemGroupRequirement
+  #   group: TraitsLanguagesBasic
+#    - !type:CharacterSpeciesRequirement
+#      inverted: true
+#      species:
+#        - Human
+#    - !type:CharacterNationalityRequirement
+#      inverted: true
+#      nationalities:
+#        - Solarian
+#  functions:
+#    - !type:TraitModifyLanguages
+#      languagesSpoken:
+#        - SolCommon
+#      languagesUnderstood:
+#        - SolCommon
+# WD EDIT END: disabled so that non-humans cannot use it
 
 - type: trait
   id: Tradeband


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

Перк общесолнечный теперь стоит 2 очка, занимает 1 слот
Перк могут взять только дварфы или фелиниды

---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl:
- tweak: Общесолнечный стоит 2 очка, занимает 1 слот и его могут брать только дварфы и фелиниды