### PR TITLE
[FIX] Алерт "В ОГНЕ" не пропадал после тушения

### DIFF
--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -312,6 +312,9 @@ namespace Content.Server.Atmos.EntitySystems
                 return;
 
             RemCompDeferred<OnFireComponent>(uid);
+            _alertsSystem.ClearAlert(uid, flammable.FireAlert);
+            RaiseLocalEvent(uid, new MoodRemoveEffectEvent("OnFire"));
+
             if (!flammable.OnFire)
                 return;
 
@@ -442,8 +445,6 @@ namespace Content.Server.Atmos.EntitySystems
 
                 if (!flammable.OnFire)
                 {
-                    _alertsSystem.ClearAlert(uid, flammable.FireAlert);
-                    RaiseLocalEvent(uid, new MoodRemoveEffectEvent("OnFire"));
                     RemCompDeferred<OnFireComponent>(uid);
                     continue;
                 }


### PR DESCRIPTION
# Описание PR

Исправлен баг, когда после тушения не пропадал алерт, уведомляющий о том, что персонаж игрока находится в огне.

---

# Изменения

:cl: DEADISKO
- fix: Алерт "В ОГНЕ"
