### PR TITLE
Fix psionics power pool

### DIFF
--- a/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.Functions.cs
+++ b/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.Functions.cs
@@ -472,7 +472,10 @@ public sealed partial class PsionicChangePowerPool : PsionicPowerFunction
         PsionicComponent psionicComponent,
         PsionicPowerPrototype proto)
     {
-        psionicComponent.PowerPool = PowerPool;
+        if (string.IsNullOrEmpty(psionicComponent.PowerPool) || psionicComponent.PowerPool == "RandomPsionicPowerPool") //WWDP EDIT
+        {
+            psionicComponent.PowerPool = PowerPool;
+        }
     }
 }
 

--- a/Content.Server/Psionics/PsionicsSystem.cs
+++ b/Content.Server/Psionics/PsionicsSystem.cs
@@ -1,31 +1,32 @@
-using Content.Shared.Abilities.Psionics;
-using Content.Shared.StatusEffect;
-using Content.Shared.Psionics;
-using Content.Shared.Psionics.Glimmer;
-using Content.Shared.Random;
-using Content.Shared.Weapons.Melee.Events;
-using Content.Shared.Damage.Events;
-using Content.Shared.CCVar;
 using Content.Server.Abilities.Psionics;
+using Content.Server.Chat.Managers;
 using Content.Server.Electrocution;
 using Content.Server.NPC.Components;
 using Content.Server.NPC.Systems;
-using Robust.Shared.Audio.Systems;
-using Robust.Shared.Configuration;
-using Robust.Shared.Random;
-using Content.Shared.Popups;
-using Content.Shared.Chat;
-using Robust.Server.Player;
-using Content.Server.Chat.Managers;
-using Robust.Shared.Prototypes;
-using Content.Shared.Mobs;
-using Content.Shared.Damage;
-using Content.Shared.Interaction.Events;
-using Timer = Robust.Shared.Timing.Timer;
+using Content.Shared._White.Psionics; //wwdp edit
+using Content.Shared.Abilities.Psionics;
 using Content.Shared.Alert;
+using Content.Shared.CCVar;
+using Content.Shared.Chat;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Events;
+using Content.Shared.Interaction.Events;
+using Content.Shared.Mobs;
 using Content.Shared.NPC.Components;
 using Content.Shared.NPC.Systems;
+using Content.Shared.Popups;
+using Content.Shared.Psionics;
+using Content.Shared.Psionics.Glimmer;
+using Content.Shared.Random;
 using Content.Shared.Rounding;
+using Content.Shared.StatusEffect;
+using Content.Shared.Weapons.Melee.Events;
+using Robust.Server.Player;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Configuration;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Server.Psionics;
 
@@ -105,6 +106,11 @@ public sealed class PsionicsSystem : EntitySystem
         if (!Exists(uid)
             || !TryComp(uid, out PsionicComponent? component))
             return;
+
+        if (TryComp<CustomPsionicPoolComponent>(uid, out var customPoolComp)) //wwdp edit start
+        {
+            component.PowerPool = customPoolComp.Pool;
+        } //wwdp edit end
 
         CheckPowerCost(uid, component);
         GenerateAvailablePowers(component);

--- a/Content.Shared/_White/Psionics/CustomPsionicPoolComponent.cs
+++ b/Content.Shared/_White/Psionics/CustomPsionicPoolComponent.cs
@@ -1,0 +1,11 @@
+using Content.Shared.Random;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._White.Psionics;
+
+[RegisterComponent]
+public sealed partial class CustomPsionicPoolComponent : Component
+{
+    [DataField(required: true)]
+    public ProtoId<WeightedRandomPrototype> Pool = "RandomPsionicPowerPool";
+}

--- a/Resources/Prototypes/Traits/Psionics/casterTypes.yml
+++ b/Resources/Prototypes/Traits/Psionics/casterTypes.yml
@@ -72,7 +72,7 @@
           nextPowerCost: 75
           removable: false
           powerPool: PsychoHistorianPowerPool
-        - type: CustomPsionicPoolComponent
+        - type: CustomPsionicPool
           pool: PsychoHistorianPowerPool
     - !type:TraitAddPsionics
       psionicPowers:

--- a/Resources/Prototypes/Traits/Psionics/casterTypes.yml
+++ b/Resources/Prototypes/Traits/Psionics/casterTypes.yml
@@ -72,6 +72,8 @@
           nextPowerCost: 75
           removable: false
           powerPool: PsychoHistorianPowerPool
+        - type: CustomPsionicPoolComponent
+          pool: PsychoHistorianPowerPool
     - !type:TraitAddPsionics
       psionicPowers:
         - TelepathyPower

--- a/Resources/Prototypes/_White/Traits/Psionics/typeCaster.yml
+++ b/Resources/Prototypes/_White/Traits/Psionics/typeCaster.yml
@@ -10,7 +10,7 @@
           nextPowerCost: 0
           removable: false
           powerPool: ShadowkinPowerPool
-        - type: CustomPsionicPoolComponent
+        - type: CustomPsionicPool
           pool: ShadowkinPowerPool
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -45,7 +45,7 @@
         - type: Psionic
           removable: false
           powerPool: InfernalPowerPool
-        - type: CustomPsionicPoolComponent
+        - type: CustomPsionicPool
           pool: InfernalPowerPool
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -80,7 +80,7 @@
         - type: Psionic
           removable: false
           powerPool: TelekineticistPowerPool
-        - type: CustomPsionicPoolComponent
+        - type: CustomPsionicPool
           pool: TelekineticistPowerPool
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -116,7 +116,7 @@
           removable: false
           powerPool: PriestPowerPool
           nextPowerCost: 0
-        - type: CustomPsionicPoolComponent
+        - type: CustomPsionicPool
           pool: PriestPowerPool
   requirements:
     - !type:CharacterItemGroupRequirement

--- a/Resources/Prototypes/_White/Traits/Psionics/typeCaster.yml
+++ b/Resources/Prototypes/_White/Traits/Psionics/typeCaster.yml
@@ -10,6 +10,8 @@
           nextPowerCost: 0
           removable: false
           powerPool: ShadowkinPowerPool
+        - type: CustomPsionicPoolComponent
+          pool: ShadowkinPowerPool
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsCasterType
@@ -43,6 +45,8 @@
         - type: Psionic
           removable: false
           powerPool: InfernalPowerPool
+        - type: CustomPsionicPoolComponent
+          pool: InfernalPowerPool
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsCasterType
@@ -76,6 +80,8 @@
         - type: Psionic
           removable: false
           powerPool: TelekineticistPowerPool
+        - type: CustomPsionicPoolComponent
+          pool: TelekineticistPowerPool
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsCasterType
@@ -110,6 +116,8 @@
           removable: false
           powerPool: PriestPowerPool
           nextPowerCost: 0
+        - type: CustomPsionicPoolComponent
+          pool: PriestPowerPool
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsCasterType


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

немного костыльная починка того, что на сервере шанс 50 на 50 получить псионику по трейду.
теперь в трейтах выдаётся ещё и компонент CustomPsionicPoolComponent, он хранит в себе powerPool, а в системе псионики при выдаче псиопики будет выставлять паверпулл который есть в этом компоненте, он должен работать нормально.

---

# Медиа

<!--
Сюда можно вставить различные видео или скриншоты, необходимые для демонстрации работоспособности пулл реквеста.
Если в этом нет необходимости, то весь пункт можно просто удалить.
-->

<details><summary>Список</summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl:
- fix: Псикасты работают