### PR TITLE
Удаление приписки "Сервер:" к сообщениям

### DIFF
--- a/Resources/Locale/ru-RU/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/ru-RU/chat/managers/chat-manager.ftl
@@ -20,7 +20,7 @@ chat-manager-whisper-headset-on-message = Вы не можете шептать 
 
 chat-manager-language-prefix = ({ $language }){" "}
 
-chat-manager-server-wrap-message = СЕРВЕР: { $message }
+chat-manager-server-wrap-message = { $message }
 chat-manager-sender-announcement = Центральное Командование
 chat-manager-sender-announcement-wrap-message = [font size=14][bold]{$sender} объявляет:[/font][font size=12]
                                                 {$message}[/bold][/font]

--- a/Resources/Locale/ru-RU/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/ru-RU/chat/managers/chat-manager.ftl
@@ -20,7 +20,7 @@ chat-manager-whisper-headset-on-message = Вы не можете шептать 
 
 chat-manager-language-prefix = ({ $language }){" "}
 
-chat-manager-server-wrap-message = [bold]{$message}[/bold]
+chat-manager-server-wrap-message = [bold]{ $message }[/bold]
 chat-manager-sender-announcement = Центральное Командование
 chat-manager-sender-announcement-wrap-message = [font size=14][bold]{$sender} объявляет:[/font][font size=12]
                                                 {$message}[/bold][/font]

--- a/Resources/Locale/ru-RU/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/ru-RU/chat/managers/chat-manager.ftl
@@ -20,7 +20,7 @@ chat-manager-whisper-headset-on-message = Вы не можете шептать 
 
 chat-manager-language-prefix = ({ $language }){" "}
 
-chat-manager-server-wrap-message = { $message }
+chat-manager-server-wrap-message = [bold]{$message}[/bold]
 chat-manager-sender-announcement = Центральное Командование
 chat-manager-sender-announcement-wrap-message = [font size=14][bold]{$sender} объявляет:[/font][font size=12]
                                                 {$message}[/bold][/font]


### PR DESCRIPTION
# Описание PR

Убирает приписку к "Сервер:" перед разными рода сообщений. Выдача антагонистов, начало раунда, и так далее (показано на скриншоте)

---

# Медиа

<img width="988" height="615" alt="image" src="https://github.com/user-attachments/assets/dcfe3833-1b6c-4643-8ebb-10837e0015ce" />


---

# Изменения


:cl:
- remove: Удалена приписка "Сервер:" к сообщениям
