### PR TITLE
[FIX] Animals NightVision component 

### DIFF
--- a/Content.Client/Overlays/EquipmentHudSystem.cs
+++ b/Content.Client/Overlays/EquipmentHudSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.GameTicking;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
+using Content.Shared.Overlays.Switchable; // WD EDIT
 using Robust.Client.Player;
 using Robust.Shared.Player;
 
@@ -94,6 +95,11 @@ public abstract class EquipmentHudSystem<T> : EntitySystem where T : IComponent
 
     protected virtual void OnRefreshEquipmentHud(Entity<T> ent, ref InventoryRelayedEvent<RefreshEquipmentHudEvent<T>> args)
     {
+        // WD EDIT START - only equipment switchable overlays should work from inventory.
+        if (ent.Comp is SwitchableOverlayComponent { IsEquipment: false })
+            return;
+        // WD EDIT END
+
         OnRefreshComponentHud(ent, ref args.Args);
     }
 

--- a/Content.Client/Overlays/Switchable/NightVisionSystem.cs
+++ b/Content.Client/Overlays/Switchable/NightVisionSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Overlays.Switchable;
 using Robust.Client.Graphics;
@@ -39,6 +40,18 @@ public sealed class NightVisionSystem : EquipmentHudSystem<NightVisionComponent>
 
         _overlay.SetParams(ent.Comp.Tint, ent.Comp.Strength, ent.Comp.Noise, ent.Comp.Color, ent.Comp.PulseTime);
         RefreshOverlay();
+    }
+
+    protected override void OnRefreshEquipmentHud(
+        Entity<NightVisionComponent> ent,
+        ref InventoryRelayedEvent<RefreshEquipmentHudEvent<NightVisionComponent>> args)
+    {
+        // WD EDIT START - only equipment night vision should work from inventory.
+        if (!ent.Comp.IsEquipment)
+            return;
+        // WD EDIT END
+
+        base.OnRefreshEquipmentHud(ent, ref args);
     }
 
     protected override void UpdateInternal(RefreshEquipmentHudEvent<NightVisionComponent> args)

--- a/Content.Client/Overlays/Switchable/NightVisionSystem.cs
+++ b/Content.Client/Overlays/Switchable/NightVisionSystem.cs
@@ -1,4 +1,3 @@
-using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Overlays.Switchable;
 using Robust.Client.Graphics;
@@ -40,18 +39,6 @@ public sealed class NightVisionSystem : EquipmentHudSystem<NightVisionComponent>
 
         _overlay.SetParams(ent.Comp.Tint, ent.Comp.Strength, ent.Comp.Noise, ent.Comp.Color, ent.Comp.PulseTime);
         RefreshOverlay();
-    }
-
-    protected override void OnRefreshEquipmentHud(
-        Entity<NightVisionComponent> ent,
-        ref InventoryRelayedEvent<RefreshEquipmentHudEvent<NightVisionComponent>> args)
-    {
-        // WD EDIT START - only equipment night vision should work from inventory.
-        if (!ent.Comp.IsEquipment)
-            return;
-        // WD EDIT END
-
-        base.OnRefreshEquipmentHud(ent, ref args);
     }
 
     protected override void UpdateInternal(RefreshEquipmentHudEvent<NightVisionComponent> args)


### PR DESCRIPTION
# Описание PR

Исправлено применение NightVision с надетых предметов: теперь компонент, найденный через инвентарь, учитывается только при isEquipment: true.
Это предотвращает случаи, когда надеваемые сущности с врождённым ночным зрением, например мышь, работают как ПНВ для носителя. Врождённый NightVision у самих мобов и штатные очки/шлемы ПНВ продолжают работать как раньше.

Описание.

---

# Медиа

<img width="2560" height="1440" alt="2026-7-06_20 26 02" src="https://github.com/user-attachments/assets/cd22da77-59c2-4d90-8482-3794e48bf891" />

---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl: DEADISKO
- fix: Мышь на голове больше не даёт ночное зрение.
