### PR TITLE
Полное здоровье не видно

### DIFF
--- a/Content.Client/Overlays/EntityHealthBarOverlay.cs
+++ b/Content.Client/Overlays/EntityHealthBarOverlay.cs
@@ -86,8 +86,8 @@ public sealed class EntityHealthBarOverlay : Overlay
             if (CalcProgress(uid, mobStateComponent, damageableComponent, mobThresholdsComponent) is not { } deathProgress)
                 continue;
 
-            if (deathProgress is (1, false))
-                continue;
+            if (deathProgress is (1, false)) //WD EDIT
+                continue;                    //WD EDIT
 
             // Including sprite offsets to support pixel-perfect eye filter
             var worldPosition = _transform.GetWorldPosition(xform) + Vector2.Transform(spriteComponent.Offset, rotationMatrix); // WWDP EDIT
@@ -168,4 +168,3 @@ public sealed class EntityHealthBarOverlay : Overlay
         return _progressColor.GetProgressColor(progress);
     }
 }
-

--- a/Content.Client/Overlays/EntityHealthBarOverlay.cs
+++ b/Content.Client/Overlays/EntityHealthBarOverlay.cs
@@ -86,41 +86,41 @@ public sealed class EntityHealthBarOverlay : Overlay
             if (CalcProgress(uid, mobStateComponent, damageableComponent, mobThresholdsComponent) is not { } deathProgress)
                 continue;
 
-            if (deathProgress is not (1, false)) // WD EDIT
-            {
-                // Including sprite offsets to support pixel-perfect eye filter
-                var worldPosition = _transform.GetWorldPosition(xform) + Vector2.Transform(spriteComponent.Offset, rotationMatrix); // WWDP EDIT
-                var worldMatrix = Matrix3Helpers.CreateTranslation(worldPosition);
+            if (deathProgress is (1, false))
+                continue;
 
-                var scaledWorld = Matrix3x2.Multiply(scaleMatrix, worldMatrix);
-                var matty = Matrix3x2.Multiply(rotationMatrix, scaledWorld);
+            // Including sprite offsets to support pixel-perfect eye filter
+            var worldPosition = _transform.GetWorldPosition(xform) + Vector2.Transform(spriteComponent.Offset, rotationMatrix); // WWDP EDIT
+            var worldMatrix = Matrix3Helpers.CreateTranslation(worldPosition);
 
-                handle.SetTransform(matty);
+            var scaledWorld = Matrix3x2.Multiply(scaleMatrix, worldMatrix);
+            var matty = Matrix3x2.Multiply(rotationMatrix, scaledWorld);
 
-                var yOffset = bounds.Height * EyeManager.PixelsPerMeter / 2 - 3f;
-                var widthOfMob = bounds.Width * EyeManager.PixelsPerMeter;
+            handle.SetTransform(matty);
 
-                var position = new Vector2(-widthOfMob / EyeManager.PixelsPerMeter / 2, yOffset / EyeManager.PixelsPerMeter);
-                var color = GetProgressColor(deathProgress.ratio, deathProgress.inCrit);
+            var yOffset = bounds.Height * EyeManager.PixelsPerMeter / 2 - 3f;
+            var widthOfMob = bounds.Width * EyeManager.PixelsPerMeter;
 
-                // Hardcoded width of the progress bar because it doesn't match the texture.
-                const float startX = 8f;
-                var endX = widthOfMob - 8f;
+            var position = new Vector2(-widthOfMob / EyeManager.PixelsPerMeter / 2, yOffset / EyeManager.PixelsPerMeter);
+            var color = GetProgressColor(deathProgress.ratio, deathProgress.inCrit);
 
-                var xProgress = (endX - startX) * deathProgress.ratio + startX;
+            // Hardcoded width of the progress bar because it doesn't match the texture.
+            const float startX = 8f;
+            var endX = widthOfMob - 8f;
 
-                var boxBackground = new Box2(new Vector2(startX, 0f) / EyeManager.PixelsPerMeter, new Vector2(endX, 3f) / EyeManager.PixelsPerMeter);
-                boxBackground = boxBackground.Translated(position);
-                handle.DrawRect(boxBackground, Black.WithAlpha(192));
+            var xProgress = (endX - startX) * deathProgress.ratio + startX;
 
-                var boxMain = new Box2(new Vector2(startX, 0f) / EyeManager.PixelsPerMeter, new Vector2(xProgress, 3f) / EyeManager.PixelsPerMeter);
-                boxMain = boxMain.Translated(position);
-                handle.DrawRect(boxMain, color);
+            var boxBackground = new Box2(new Vector2(startX, 0f) / EyeManager.PixelsPerMeter, new Vector2(endX, 3f) / EyeManager.PixelsPerMeter);
+            boxBackground = boxBackground.Translated(position);
+            handle.DrawRect(boxBackground, Black.WithAlpha(192));
 
-                var pixelDarken = new Box2(new Vector2(startX, 2f) / EyeManager.PixelsPerMeter, new Vector2(xProgress, 3f) / EyeManager.PixelsPerMeter);
-                pixelDarken = pixelDarken.Translated(position);
-                handle.DrawRect(pixelDarken, Black.WithAlpha(128));
-            }
+            var boxMain = new Box2(new Vector2(startX, 0f) / EyeManager.PixelsPerMeter, new Vector2(xProgress, 3f) / EyeManager.PixelsPerMeter);
+            boxMain = boxMain.Translated(position);
+            handle.DrawRect(boxMain, color);
+
+            var pixelDarken = new Box2(new Vector2(startX, 2f) / EyeManager.PixelsPerMeter, new Vector2(xProgress, 3f) / EyeManager.PixelsPerMeter);
+            pixelDarken = pixelDarken.Translated(position);
+            handle.DrawRect(pixelDarken, Black.WithAlpha(128));
         }
 
         handle.SetTransform(Matrix3x2.Identity);

--- a/Content.Client/Overlays/EntityHealthBarOverlay.cs
+++ b/Content.Client/Overlays/EntityHealthBarOverlay.cs
@@ -82,6 +82,11 @@ public sealed class EntityHealthBarOverlay : Overlay
             if (!bounds.Translated(worldPos).Intersects(args.WorldAABB))
                 continue;
 
+            // WD EDIT START
+            if (CalcProgress(uid, mobStateComponent, damageableComponent, mobThresholdsComponent) is (1, false))
+                return;
+            // WD EDIT END
+
             // we are all progressing towards death every day
             if (CalcProgress(uid, mobStateComponent, damageableComponent, mobThresholdsComponent) is not { } deathProgress)
                 continue;

--- a/Content.Client/Overlays/EntityHealthBarOverlay.cs
+++ b/Content.Client/Overlays/EntityHealthBarOverlay.cs
@@ -82,47 +82,45 @@ public sealed class EntityHealthBarOverlay : Overlay
             if (!bounds.Translated(worldPos).Intersects(args.WorldAABB))
                 continue;
 
-            // WD EDIT START
-            if (CalcProgress(uid, mobStateComponent, damageableComponent, mobThresholdsComponent) is (1, false))
-                return;
-            // WD EDIT END
-
             // we are all progressing towards death every day
             if (CalcProgress(uid, mobStateComponent, damageableComponent, mobThresholdsComponent) is not { } deathProgress)
                 continue;
 
-            // Including sprite offsets to support pixel-perfect eye filter
-            var worldPosition = _transform.GetWorldPosition(xform) + Vector2.Transform(spriteComponent.Offset, rotationMatrix); // WWDP EDIT
-            var worldMatrix = Matrix3Helpers.CreateTranslation(worldPosition);
+            if (deathProgress is not (1, false)) // WD EDIT
+            {
+                // Including sprite offsets to support pixel-perfect eye filter
+                var worldPosition = _transform.GetWorldPosition(xform) + Vector2.Transform(spriteComponent.Offset, rotationMatrix); // WWDP EDIT
+                var worldMatrix = Matrix3Helpers.CreateTranslation(worldPosition);
 
-            var scaledWorld = Matrix3x2.Multiply(scaleMatrix, worldMatrix);
-            var matty = Matrix3x2.Multiply(rotationMatrix, scaledWorld);
+                var scaledWorld = Matrix3x2.Multiply(scaleMatrix, worldMatrix);
+                var matty = Matrix3x2.Multiply(rotationMatrix, scaledWorld);
 
-            handle.SetTransform(matty);
+                handle.SetTransform(matty);
 
-            var yOffset = bounds.Height * EyeManager.PixelsPerMeter / 2 - 3f;
-            var widthOfMob = bounds.Width * EyeManager.PixelsPerMeter;
+                var yOffset = bounds.Height * EyeManager.PixelsPerMeter / 2 - 3f;
+                var widthOfMob = bounds.Width * EyeManager.PixelsPerMeter;
 
-            var position = new Vector2(-widthOfMob / EyeManager.PixelsPerMeter / 2, yOffset / EyeManager.PixelsPerMeter);
-            var color = GetProgressColor(deathProgress.ratio, deathProgress.inCrit);
+                var position = new Vector2(-widthOfMob / EyeManager.PixelsPerMeter / 2, yOffset / EyeManager.PixelsPerMeter);
+                var color = GetProgressColor(deathProgress.ratio, deathProgress.inCrit);
 
-            // Hardcoded width of the progress bar because it doesn't match the texture.
-            const float startX = 8f;
-            var endX = widthOfMob - 8f;
+                // Hardcoded width of the progress bar because it doesn't match the texture.
+                const float startX = 8f;
+                var endX = widthOfMob - 8f;
 
-            var xProgress = (endX - startX) * deathProgress.ratio + startX;
+                var xProgress = (endX - startX) * deathProgress.ratio + startX;
 
-            var boxBackground = new Box2(new Vector2(startX, 0f) / EyeManager.PixelsPerMeter, new Vector2(endX, 3f) / EyeManager.PixelsPerMeter);
-            boxBackground = boxBackground.Translated(position);
-            handle.DrawRect(boxBackground, Black.WithAlpha(192));
+                var boxBackground = new Box2(new Vector2(startX, 0f) / EyeManager.PixelsPerMeter, new Vector2(endX, 3f) / EyeManager.PixelsPerMeter);
+                boxBackground = boxBackground.Translated(position);
+                handle.DrawRect(boxBackground, Black.WithAlpha(192));
 
-            var boxMain = new Box2(new Vector2(startX, 0f) / EyeManager.PixelsPerMeter, new Vector2(xProgress, 3f) / EyeManager.PixelsPerMeter);
-            boxMain = boxMain.Translated(position);
-            handle.DrawRect(boxMain, color);
+                var boxMain = new Box2(new Vector2(startX, 0f) / EyeManager.PixelsPerMeter, new Vector2(xProgress, 3f) / EyeManager.PixelsPerMeter);
+                boxMain = boxMain.Translated(position);
+                handle.DrawRect(boxMain, color);
 
-            var pixelDarken = new Box2(new Vector2(startX, 2f) / EyeManager.PixelsPerMeter, new Vector2(xProgress, 3f) / EyeManager.PixelsPerMeter);
-            pixelDarken = pixelDarken.Translated(position);
-            handle.DrawRect(pixelDarken, Black.WithAlpha(128));
+                var pixelDarken = new Box2(new Vector2(startX, 2f) / EyeManager.PixelsPerMeter, new Vector2(xProgress, 3f) / EyeManager.PixelsPerMeter);
+                pixelDarken = pixelDarken.Translated(position);
+                handle.DrawRect(pixelDarken, Black.WithAlpha(128));
+            }
         }
 
         handle.SetTransform(Matrix3x2.Identity);
@@ -170,3 +168,4 @@ public sealed class EntityHealthBarOverlay : Overlay
         return _progressColor.GetProgressColor(progress);
     }
 }
+


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR

<!--
Описание пулл реквеста. Что он изменяет? На что он может повлиять? Почему было решено сделать эти изменения?
-->

Медхуд больше не показывает здоровье если оно полное, потому что это мозолит глаза и бессмысленно

---

# Медиа

<!--
Сюда можно вставить различные видео или скриншоты, необходимые для демонстрации работоспособности пулл реквеста.
Если в этом нет необходимости, то весь пункт можно просто удалить.
-->

<details><summary>Список</summary>
<p>

<img width="180" height="136" alt="изображение" src="https://github.com/user-attachments/assets/fc11c768-87f0-4d37-b62d-6fe43bdd354f" />


</p>
</details>

---

# Изменения

<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.
Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: ":cl: DVOniksWyvern".
-->

:cl: dettern
- tweak: Медхуд не отображает полное здоровье
