### PR TITLE
[Fix] Фиксы таймера строений культа и ночного зрения

### DIFF
--- a/Content.Client/Overlays/Switchable/NightVisionSystem.cs
+++ b/Content.Client/Overlays/Switchable/NightVisionSystem.cs
@@ -62,6 +62,11 @@ public sealed class NightVisionSystem : EquipmentHudSystem<NightVisionComponent>
                 break;
         }
 
+        // WD EDIT START - apply prototype parameters for night vision that starts active.
+        if (nvComp != null)
+            _overlay.SetParams(nvComp.Tint, nvComp.Strength, nvComp.Noise, nvComp.Color, nvComp.PulseTime);
+        // WD EDIT END
+
         UpdateNightVision(active);
     }
 

--- a/Content.Shared/_White/BloodCult/TimedFactory/TimedFactorySystem.cs
+++ b/Content.Shared/_White/BloodCult/TimedFactory/TimedFactorySystem.cs
@@ -32,12 +32,12 @@ public sealed class TimedFactorySystem : EntitySystem
         while (factoryQuery.MoveNext(out var uid, out var factory))
         {
             if (factory.Active)
-                return;
+                continue;
 
             factory.CooldownRemain -= frameTime;
             Dirty(uid, factory);
             if (factory.CooldownRemain > 0)
-                return;
+                continue;
 
             factory.Active = true;
             _appearance.SetData(uid, GenericCultVisuals.State, true);


### PR DESCRIPTION
# Описание PR

- Исправлен баг, когда таймер строения культа не начинал отсчёт;
- Исправлен баг, из-за которого вместо заданного цвета в прототипе сущности с компонентом ночного зрения отображался красный цвет.

---


# Изменения

:cl: DEADISKO
- fix: Цвет ночного зрения
- fix: Таймер у структур культа