### PR TITLE
[Feature] Antag purchase list

### DIFF
--- a/Content.Client/_White/AntagPurchaseHistory/AntagPurchaseTag.cs
+++ b/Content.Client/_White/AntagPurchaseHistory/AntagPurchaseTag.cs
@@ -1,0 +1,153 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Numerics;
+using Content.Client.Actions;
+using Content.Shared._White.AntagPurchaseHistory;
+using Content.Shared.FixedPoint;
+using Content.Shared.Store;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.CustomControls;
+using Robust.Client.UserInterface.RichText;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Client._White.AntagPurchaseHistory;
+
+/// <summary>
+/// Renders a store listing icon embedded in rich text and supplies its historical purchase price as a tooltip.
+/// </summary>
+public sealed class AntagPurchaseTag : IMarkupTagHandler
+{
+    private static readonly SpriteSpecifier ErrorIcon =
+        new SpriteSpecifier.Rsi(new ResPath("/Textures/error.rsi"), "error");
+
+    [Dependency] private readonly IEntityManager _entities = default!;
+    [Dependency] private readonly IPrototypeManager _prototypes = default!;
+
+    public string Name => AntagPurchaseMarkup.TagName;
+
+    public bool TryCreateControl(MarkupNode node, [NotNullWhen(true)] out Control? control)
+    {
+        control = null;
+        if (node.Closing ||
+            !node.Value.TryGetString(out var listingId) ||
+            !TryGetCost(node, AntagPurchaseMarkup.FinalCostAttribute, out var finalCost) ||
+            !TryGetCost(node, AntagPurchaseMarkup.OriginalCostAttribute, out var originalCost))
+        {
+            return false;
+        }
+
+        var texture = GetListingTexture(listingId);
+        var listingName = GetListingName(listingId);
+        var icon = new TextureRect
+        {
+            Texture = texture,
+            SetSize = new Vector2(AntagPurchaseMarkup.IconSize, AntagPurchaseMarkup.IconSize),
+            Stretch = TextureRect.StretchMode.KeepAspectCentered,
+            MouseFilter = Control.MouseFilterMode.Stop,
+            TooltipSupplier = _ => CreatePriceTooltip(listingName, originalCost, finalCost),
+        };
+
+        control = icon;
+        return true;
+    }
+
+    private bool TryGetCost(
+        MarkupNode node,
+        string attribute,
+        out Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2> cost)
+    {
+        cost = new Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2>();
+        return node.Attributes.TryGetValue(attribute, out var parameter) &&
+               parameter.TryGetString(out var serialized) &&
+               AntagPurchaseMarkup.TryDeserializeCost(serialized, out cost);
+    }
+
+    private Texture? GetListingTexture(string listingId)
+    {
+        // The stripped-down integration-test client does not load rendering systems.
+        // In the game SpriteSystem is always available; keeping the control lets markup and tooltip tests
+        // run headlessly.
+        if (!_entities.EntitySysManager.TryGetEntitySystem<SpriteSystem>(out var sprites))
+            return null;
+
+        if (!_prototypes.TryIndex<ListingPrototype>(listingId, out var listing))
+            return sprites.Frame0(ErrorIcon);
+
+        if (listing.Icon != null)
+            return sprites.Frame0(listing.Icon);
+
+        if (listing.ProductEntity != null)
+            return sprites.GetPrototypeIcon(listing.ProductEntity.Value).Default;
+
+        if (listing.ProductAction != null)
+        {
+            var actionUid = _entities.Spawn(listing.ProductAction);
+            try
+            {
+                if (_entities.System<ActionsSystem>().TryGetActionData(actionUid, out var action) &&
+                    action.Icon != null)
+                {
+                    return sprites.Frame0(action.Icon);
+                }
+            }
+            finally
+            {
+                _entities.DeleteEntity(actionUid);
+            }
+        }
+
+        return sprites.Frame0(ErrorIcon);
+    }
+
+    private string GetListingName(string listingId)
+    {
+        if (!_prototypes.TryIndex<ListingPrototype>(listingId, out var listing))
+            return listingId;
+
+        var name = ListingLocalisationHelpers.GetLocalisedNameOrEntityName(listing, _prototypes);
+        return string.IsNullOrWhiteSpace(name) ? listingId : name;
+    }
+
+    private Tooltip CreatePriceTooltip(
+        string listingName,
+        IReadOnlyDictionary<ProtoId<CurrencyPrototype>, FixedPoint2> originalCost,
+        IReadOnlyDictionary<ProtoId<CurrencyPrototype>, FixedPoint2> finalCost)
+    {
+        var tooltip = new Tooltip();
+        var message = new FormattedMessage();
+        message.AddText($"{listingName}: ");
+
+        if (AntagPurchaseMarkup.HasDiscount(originalCost, finalCost))
+        {
+            message.PushColor(Color.Red);
+            message.AddText(GetPriceString(originalCost));
+            message.Pop();
+            message.AddText(" | ");
+        }
+
+        message.AddText(GetPriceString(finalCost));
+        tooltip.SetMessage(message);
+        return tooltip;
+    }
+
+    private string GetPriceString(IReadOnlyDictionary<ProtoId<CurrencyPrototype>, FixedPoint2> cost)
+    {
+        if (cost.Count == 0)
+            return Loc.GetString("store-currency-free");
+
+        return string.Join(", ", cost.Select(pair =>
+        {
+            if (!_prototypes.TryIndex(pair.Key, out CurrencyPrototype? currency))
+                return $"{pair.Value} {pair.Key.Id}";
+
+            return Loc.GetString(
+                "store-ui-price-display",
+                ("amount", pair.Value),
+                ("currency", Loc.GetString(currency.DisplayName, ("amount", pair.Value))));
+        }));
+    }
+}

--- a/Content.IntegrationTests/Tests/_White/AntagPurchaseHistoryTests.cs
+++ b/Content.IntegrationTests/Tests/_White/AntagPurchaseHistoryTests.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using Content.Server._White.AntagPurchaseHistory;
+using Content.Server.GameTicking;
+using Content.Server.GameTicking.Rules;
 using Content.Server.Objectives;
 using Content.Shared._White.AntagPurchaseHistory;
 using Content.Shared.FixedPoint;
@@ -49,6 +51,14 @@ public sealed class AntagPurchaseHistoryTests
     WizCoin: 4
   categories:
   - UplinkWeaponry
+
+- type: entity
+  id: AntagPurchaseHistoryTestRule
+  parent: BaseGameRule
+  components:
+  - type: GenericAntagRule
+    agentName: traitor-round-end-agent-name
+    objectives: []
 ";
 
     [Test]
@@ -76,6 +86,11 @@ public sealed class AntagPurchaseHistoryTests
             mindSystem.TransferTo(antagMind, antagBuyer, mind: antagMind.Comp);
             roleSystem.MindAddRole(antagMind, "MindRoleTraitor", mind: antagMind.Comp);
             Assert.That(roleSystem.MindIsAntagonist(antagMind));
+            Assert.That(entManager.System<GenericAntagRuleSystem>().StartRule(
+                "AntagPurchaseHistoryTestRule",
+                antagMind,
+                out _,
+                out _));
 
             storeUid = entManager.SpawnEntity("AntagPurchaseHistoryTestStore", testMap.GridCoords);
             var store = entManager.GetComponent<StoreComponent>(storeUid);
@@ -103,7 +118,6 @@ public sealed class AntagPurchaseHistoryTests
             Assert.Multiple(() =>
             {
                 Assert.That(purchase.ListingId.Id, Is.EqualTo("AntagPurchaseHistoryTestListing"));
-                Assert.That(purchase.DisplayName, Is.Not.Null.And.Not.Empty);
                 Assert.That(purchase.FinalCost["Telecrystal"], Is.EqualTo((FixedPoint2) 7));
                 Assert.That(purchase.FinalCost["WizCoin"], Is.EqualTo((FixedPoint2) 3));
                 Assert.That(purchase.OriginalCost["Telecrystal"], Is.EqualTo((FixedPoint2) 10));
@@ -126,6 +140,8 @@ public sealed class AntagPurchaseHistoryTests
             roundEndMarkup = entManager.System<AntagPurchaseHistorySystem>().GetRoundEndMarkup(antagMind);
             var additionalInfo = new ObjectivesTextGetAdditionalInfoEvent(new List<string>());
             entManager.EventBus.RaiseLocalEvent(antagMind, ref additionalInfo);
+            var roundEnd = new RoundEndTextAppendEvent();
+            entManager.EventBus.RaiseEvent(EventSource.Local, roundEnd);
             var parsed = FormattedMessage.FromMarkupOrThrow(roundEndMarkup);
             var iconNodes = parsed.Nodes
                 .Where(node => node is { Closing: false, Name: AntagPurchaseMarkup.TagName })
@@ -137,6 +153,8 @@ public sealed class AntagPurchaseHistoryTests
                 Assert.That(parsed.ToString(), Does.Contain(", 10"));
                 Assert.That(parsed.ToString(), Does.EndWith("[2x ], []"));
                 Assert.That(additionalInfo.Lines, Is.EqualTo(new[] { roundEndMarkup }));
+                Assert.That(antagMind.Comp.Objectives, Is.Empty);
+                Assert.That(roundEnd.Text, Does.Contain(roundEndMarkup));
                 Assert.That(parsed.Nodes.Any(node => node.Name == "font"), Is.False);
                 Assert.That(iconNodes, Has.Length.EqualTo(2));
                 Assert.That(iconNodes[0].Value.StringValue, Is.EqualTo("AntagPurchaseHistoryTestListing"));

--- a/Content.IntegrationTests/Tests/_White/AntagPurchaseHistoryTests.cs
+++ b/Content.IntegrationTests/Tests/_White/AntagPurchaseHistoryTests.cs
@@ -1,0 +1,123 @@
+using System.Collections.Generic;
+using System.Linq;
+using Content.Shared._White.AntagPurchaseHistory;
+using Content.Shared.FixedPoint;
+using Content.Shared.Mind;
+using Content.Shared.Roles;
+using Content.Shared.Store;
+using Content.Shared.Store.Components;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests._White;
+
+[TestFixture]
+public sealed class AntagPurchaseHistoryTests
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: AntagPurchaseHistoryTestStore
+  components:
+  - type: Store
+    categories:
+    - UplinkWeaponry
+    currencyWhitelist:
+    - Telecrystal
+    - WizCoin
+    balance:
+      Telecrystal: 100
+      WizCoin: 100
+    refundAllowed: true
+
+- type: entity
+  id: AntagPurchaseHistoryTestProduct
+  parent: BaseItem
+
+- type: listing
+  id: AntagPurchaseHistoryTestListing
+  name: antag purchase history test item
+  productEntity: AntagPurchaseHistoryTestProduct
+  cost:
+    Telecrystal: 10
+    WizCoin: 4
+  categories:
+  - UplinkWeaponry
+";
+
+    [Test]
+    public async Task PurchaseSnapshotsAntagCostsCurrenciesAndRefund()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entManager = server.EntMan;
+        var testMap = await pair.CreateTestMap();
+        await server.WaitIdleAsync();
+
+        await server.WaitAssertion(() =>
+        {
+            var mindSystem = entManager.System<SharedMindSystem>();
+            var roleSystem = entManager.System<SharedRoleSystem>();
+
+            var antagBuyer = entManager.SpawnEntity("MobHuman", testMap.GridCoords);
+            var antagMind = mindSystem.CreateMind(null);
+            mindSystem.TransferTo(antagMind, antagBuyer, mind: antagMind.Comp);
+            roleSystem.MindAddRole(antagMind, "MindRoleTraitor", mind: antagMind.Comp);
+            Assert.That(roleSystem.MindIsAntagonist(antagMind));
+
+            var storeUid = entManager.SpawnEntity("AntagPurchaseHistoryTestStore", testMap.GridCoords);
+            var store = entManager.GetComponent<StoreComponent>(storeUid);
+            var listing = store.FullListingsCatalog.Single(item => item.ID == "AntagPurchaseHistoryTestListing");
+            listing.AddCostModifier("test-discount", new Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2>
+            {
+                ["Telecrystal"] = -3,
+                ["WizCoin"] = -1,
+            });
+
+            var buyMessage = new StoreBuyListingMessage(listing.ID) { Actor = antagBuyer };
+            entManager.EventBus.RaiseComponentEvent(storeUid, store, buyMessage);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(entManager.HasComponent<AntagPurchaseHistoryComponent>(antagBuyer), Is.False,
+                    "History must be stored on the mind, not its current body.");
+                Assert.That(entManager.TryGetComponent<AntagPurchaseHistoryComponent>(antagMind, out var history));
+                Assert.That(history!.Purchases, Has.Count.EqualTo(1));
+            });
+
+            var purchase = entManager.GetComponent<AntagPurchaseHistoryComponent>(antagMind).Purchases.Single();
+            Assert.Multiple(() =>
+            {
+                Assert.That(purchase.ListingId.Id, Is.EqualTo("AntagPurchaseHistoryTestListing"));
+                Assert.That(purchase.DisplayName, Is.Not.Null.And.Not.Empty);
+                Assert.That(purchase.FinalCost["Telecrystal"], Is.EqualTo((FixedPoint2) 7));
+                Assert.That(purchase.FinalCost["WizCoin"], Is.EqualTo((FixedPoint2) 3));
+                Assert.That(purchase.OriginalCost["Telecrystal"], Is.EqualTo((FixedPoint2) 10));
+                Assert.That(purchase.OriginalCost["WizCoin"], Is.EqualTo((FixedPoint2) 4));
+                Assert.That(purchase.Refunded, Is.False);
+            });
+
+            // Mutating the live listing after purchase must not alter the stored snapshot.
+            listing.RemoveCostModifier("test-discount");
+            Assert.That(purchase.FinalCost["Telecrystal"], Is.EqualTo((FixedPoint2) 7));
+
+            var refundMessage = new StoreRequestRefundMessage { Actor = antagBuyer };
+            entManager.EventBus.RaiseComponentEvent(storeUid, store, refundMessage);
+            Assert.That(purchase.Refunded, Is.True);
+
+            var nonAntagBuyer = entManager.SpawnEntity("MobHuman", testMap.GridCoords);
+            var nonAntagMind = mindSystem.CreateMind(null);
+            mindSystem.TransferTo(nonAntagMind, nonAntagBuyer, mind: nonAntagMind.Comp);
+            Assert.That(roleSystem.MindIsAntagonist(nonAntagMind), Is.False);
+
+            var secondStoreUid = entManager.SpawnEntity("AntagPurchaseHistoryTestStore", testMap.GridCoords);
+            var secondStore = entManager.GetComponent<StoreComponent>(secondStoreUid);
+            var nonAntagBuy = new StoreBuyListingMessage("AntagPurchaseHistoryTestListing") { Actor = nonAntagBuyer };
+            entManager.EventBus.RaiseComponentEvent(secondStoreUid, secondStore, nonAntagBuy);
+
+            Assert.That(entManager.HasComponent<AntagPurchaseHistoryComponent>(nonAntagMind), Is.False);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/_White/AntagPurchaseHistoryTests.cs
+++ b/Content.IntegrationTests/Tests/_White/AntagPurchaseHistoryTests.cs
@@ -1,13 +1,19 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
+using Content.Server._White.AntagPurchaseHistory;
+using Content.Server.Objectives;
 using Content.Shared._White.AntagPurchaseHistory;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mind;
 using Content.Shared.Roles;
 using Content.Shared.Store;
 using Content.Shared.Store.Components;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Content.IntegrationTests.Tests._White;
 
@@ -50,22 +56,28 @@ public sealed class AntagPurchaseHistoryTests
     {
         await using var pair = await PoolManager.GetServerClient();
         var server = pair.Server;
+        var client = pair.Client;
         var entManager = server.EntMan;
         var testMap = await pair.CreateTestMap();
         await server.WaitIdleAsync();
+
+        EntityUid antagBuyer = default;
+        Entity<MindComponent> antagMind = default;
+        EntityUid storeUid = default;
+        string roundEndMarkup = string.Empty;
 
         await server.WaitAssertion(() =>
         {
             var mindSystem = entManager.System<SharedMindSystem>();
             var roleSystem = entManager.System<SharedRoleSystem>();
 
-            var antagBuyer = entManager.SpawnEntity("MobHuman", testMap.GridCoords);
-            var antagMind = mindSystem.CreateMind(null);
+            antagBuyer = entManager.SpawnEntity("MobHuman", testMap.GridCoords);
+            antagMind = mindSystem.CreateMind(null);
             mindSystem.TransferTo(antagMind, antagBuyer, mind: antagMind.Comp);
             roleSystem.MindAddRole(antagMind, "MindRoleTraitor", mind: antagMind.Comp);
             Assert.That(roleSystem.MindIsAntagonist(antagMind));
 
-            var storeUid = entManager.SpawnEntity("AntagPurchaseHistoryTestStore", testMap.GridCoords);
+            storeUid = entManager.SpawnEntity("AntagPurchaseHistoryTestStore", testMap.GridCoords);
             var store = entManager.GetComponent<StoreComponent>(storeUid);
             var listing = store.FullListingsCatalog.Single(item => item.ID == "AntagPurchaseHistoryTestListing");
             listing.AddCostModifier("test-discount", new Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2>
@@ -76,16 +88,18 @@ public sealed class AntagPurchaseHistoryTests
 
             var buyMessage = new StoreBuyListingMessage(listing.ID) { Actor = antagBuyer };
             entManager.EventBus.RaiseComponentEvent(storeUid, store, buyMessage);
+            entManager.EventBus.RaiseComponentEvent(storeUid, store, buyMessage);
 
             Assert.Multiple(() =>
             {
                 Assert.That(entManager.HasComponent<AntagPurchaseHistoryComponent>(antagBuyer), Is.False,
                     "History must be stored on the mind, not its current body.");
                 Assert.That(entManager.TryGetComponent<AntagPurchaseHistoryComponent>(antagMind, out var history));
-                Assert.That(history!.Purchases, Has.Count.EqualTo(1));
+                Assert.That(history!.Purchases, Has.Count.EqualTo(2));
             });
 
-            var purchase = entManager.GetComponent<AntagPurchaseHistoryComponent>(antagMind).Purchases.Single();
+            var purchases = entManager.GetComponent<AntagPurchaseHistoryComponent>(antagMind).Purchases;
+            var purchase = purchases[0];
             Assert.Multiple(() =>
             {
                 Assert.That(purchase.ListingId.Id, Is.EqualTo("AntagPurchaseHistoryTestListing"));
@@ -101,9 +115,81 @@ public sealed class AntagPurchaseHistoryTests
             listing.RemoveCostModifier("test-discount");
             Assert.That(purchase.FinalCost["Telecrystal"], Is.EqualTo((FixedPoint2) 7));
 
+            entManager.EventBus.RaiseComponentEvent(storeUid, store, buyMessage);
+            Assert.That(purchases, Has.Count.EqualTo(3));
+            Assert.Multiple(() =>
+            {
+                Assert.That(purchases[2].FinalCost["Telecrystal"], Is.EqualTo((FixedPoint2) 10));
+                Assert.That(purchases[2].FinalCost["WizCoin"], Is.EqualTo((FixedPoint2) 4));
+            });
+
+            roundEndMarkup = entManager.System<AntagPurchaseHistorySystem>().GetRoundEndMarkup(antagMind);
+            var additionalInfo = new ObjectivesTextGetAdditionalInfoEvent(new List<string>());
+            entManager.EventBus.RaiseLocalEvent(antagMind, ref additionalInfo);
+            var parsed = FormattedMessage.FromMarkupOrThrow(roundEndMarkup);
+            var iconNodes = parsed.Nodes
+                .Where(node => node is { Closing: false, Name: AntagPurchaseMarkup.TagName })
+                .ToArray();
+            Assert.Multiple(() =>
+            {
+                Assert.That(parsed.ToString(), Does.StartWith("("));
+                Assert.That(parsed.ToString(), Does.Contain("24"));
+                Assert.That(parsed.ToString(), Does.Contain(", 10"));
+                Assert.That(parsed.ToString(), Does.EndWith("[2x ], []"));
+                Assert.That(additionalInfo.Lines, Is.EqualTo(new[] { roundEndMarkup }));
+                Assert.That(parsed.Nodes.Any(node => node.Name == "font"), Is.False);
+                Assert.That(iconNodes, Has.Length.EqualTo(2));
+                Assert.That(iconNodes[0].Value.StringValue, Is.EqualTo("AntagPurchaseHistoryTestListing"));
+                Assert.That(iconNodes[0].Attributes[AntagPurchaseMarkup.FinalCostAttribute].StringValue,
+                    Is.EqualTo("Telecrystal:700;WizCoin:300"));
+                Assert.That(iconNodes[1].Attributes[AntagPurchaseMarkup.FinalCostAttribute].StringValue,
+                    Is.EqualTo("Telecrystal:1000;WizCoin:400"));
+            });
+        });
+
+        await client.WaitPost(() =>
+        {
+            var label = new RichTextLabel();
+            label.SetMessage(FormattedMessage.FromMarkupOrThrow(roundEndMarkup));
+            var icons = label.Controls.Cast<TextureRect>().ToArray();
+
+            Assert.That(icons, Has.Length.EqualTo(2));
+            Assert.That(
+                icons.Select(icon => icon.SetSize),
+                Is.All.EqualTo(new Vector2(AntagPurchaseMarkup.IconSize, AntagPurchaseMarkup.IconSize)));
+            Assert.That(icons, Has.All.Property(nameof(TextureRect.TooltipSupplier)).Not.Null);
+
+            var discountedTooltip = icons[0].TooltipSupplier!(icons[0]) as Tooltip;
+            var fullPriceTooltip = icons[1].TooltipSupplier!(icons[1]) as Tooltip;
+            Assert.Multiple(() =>
+            {
+                Assert.That(discountedTooltip, Is.Not.Null);
+                Assert.That(discountedTooltip!.Text,
+                    Does.StartWith("antag purchase history test item: "));
+                Assert.That(discountedTooltip.Text, Does.Contain("[color=red]"));
+                Assert.That(discountedTooltip.Text, Does.Contain(" | "));
+                Assert.That(fullPriceTooltip, Is.Not.Null);
+                Assert.That(fullPriceTooltip!.Text,
+                    Does.StartWith("antag purchase history test item: "));
+                Assert.That(fullPriceTooltip.Text, Does.Not.Contain("[color=red]"));
+                Assert.That(fullPriceTooltip.Text, Does.Not.Contain(" | "));
+            });
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            var mindSystem = entManager.System<SharedMindSystem>();
+            var roleSystem = entManager.System<SharedRoleSystem>();
+            var store = entManager.GetComponent<StoreComponent>(storeUid);
+
             var refundMessage = new StoreRequestRefundMessage { Actor = antagBuyer };
             entManager.EventBus.RaiseComponentEvent(storeUid, store, refundMessage);
-            Assert.That(purchase.Refunded, Is.True);
+            var purchases = entManager.GetComponent<AntagPurchaseHistoryComponent>(antagMind).Purchases;
+            Assert.Multiple(() =>
+            {
+                Assert.That(purchases, Has.All.Property(nameof(AntagPurchaseRecord.Refunded)).True);
+                Assert.That(entManager.System<AntagPurchaseHistorySystem>().GetRoundEndMarkup(antagMind), Is.Empty);
+            });
 
             var nonAntagBuyer = entManager.SpawnEntity("MobHuman", testMap.GridCoords);
             var nonAntagMind = mindSystem.CreateMind(null);

--- a/Content.Server/Objectives/ObjectivesSystem.cs
+++ b/Content.Server/Objectives/ObjectivesSystem.cs
@@ -153,6 +153,13 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
             var agentSummary = new StringBuilder();
             agentSummary.AppendLine(Loc.GetString("objectives-with-objectives", ("custody", custody), ("title", title), ("agent", agent)));
 
+            // WD EDIT START - let White features add lines immediately below the antagonist heading.
+            var additionalInfo = new ObjectivesTextGetAdditionalInfoEvent(new List<string>());
+            RaiseLocalEvent(mindId, ref additionalInfo);
+            foreach (var line in additionalInfo.Lines)
+                agentSummary.AppendLine(line);
+            // WD EDIT END
+
             foreach (var objectiveGroup in objectives.GroupBy(o => Comp<ObjectiveComponent>(o).LocIssuer))
             {
                 //TO DO:
@@ -317,3 +324,11 @@ public record struct ObjectivesTextGetInfoEvent(List<(EntityUid, string)> Minds,
 /// </summary>
 [ByRefEvent]
 public record struct ObjectivesTextPrependEvent(string Text);
+
+// WD EDIT START - event extension point for White round-end details.
+/// <summary>
+/// Raised on a mind to collect additional lines displayed immediately below its antagonist heading.
+/// </summary>
+[ByRefEvent]
+public record struct ObjectivesTextGetAdditionalInfoEvent(List<string> Lines);
+// WD EDIT END

--- a/Content.Server/Objectives/ObjectivesSystem.cs
+++ b/Content.Server/Objectives/ObjectivesSystem.cs
@@ -142,20 +142,35 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
             var custody = IsInCustody(mindId, mind) ? Loc.GetString("objectives-in-custody") : string.Empty;
 
             var objectives = mind.Objectives;
+
+            // WD EDIT START - let White features add lines below the antagonist heading, even without objectives.
+            var additionalInfo = new ObjectivesTextGetAdditionalInfoEvent(new List<string>());
+            RaiseLocalEvent(mindId, ref additionalInfo);
+
             if (objectives.Count == 0)
             {
-                agentSummaries.Add((Loc.GetString("objectives-no-objectives", ("custody", custody), ("title", title), ("agent", agent)), 0f, 0));
+                var noObjectivesSummary = new StringBuilder(Loc.GetString(
+                    "objectives-no-objectives",
+                    ("custody", custody),
+                    ("title", title),
+                    ("agent", agent)));
+                foreach (var line in additionalInfo.Lines)
+                {
+                    noObjectivesSummary.AppendLine();
+                    noObjectivesSummary.Append(line);
+                }
+
+                agentSummaries.Add((noObjectivesSummary.ToString(), 0f, 0));
                 continue;
             }
+            // WD EDIT END
 
             var completedObjectives = 0;
             var totalObjectives = 0;
             var agentSummary = new StringBuilder();
             agentSummary.AppendLine(Loc.GetString("objectives-with-objectives", ("custody", custody), ("title", title), ("agent", agent)));
 
-            // WD EDIT START - let White features add lines immediately below the antagonist heading.
-            var additionalInfo = new ObjectivesTextGetAdditionalInfoEvent(new List<string>());
-            RaiseLocalEvent(mindId, ref additionalInfo);
+            // WD EDIT START - append the collected White round-end details.
             foreach (var line in additionalInfo.Lines)
                 agentSummary.AppendLine(line);
             // WD EDIT END

--- a/Content.Server/Store/Systems/StoreSystem.Ui.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Ui.cs
@@ -370,6 +370,12 @@ public sealed partial class StoreSystem
         // Reset store back to its original state
         RefreshAllListings(component);
         component.BalanceSpent = new();
+
+        // WD EDIT START - notify White purchase history only after the aggregate refund succeeds.
+        var refundFinished = new StoreRefundFinishedEvent(buyer, uid);
+        RaiseLocalEvent(ref refundFinished);
+        // WD EDIT END
+
         UpdateUserInterface(buyer, uid, component);
     }
 

--- a/Content.Server/_White/AntagPurchaseHistory/AntagPurchaseHistorySystem.cs
+++ b/Content.Server/_White/AntagPurchaseHistory/AntagPurchaseHistorySystem.cs
@@ -1,10 +1,13 @@
 using System.Linq;
+using Content.Server.Objectives;
 using Content.Server.StoreDiscount.Systems;
 using Content.Shared._White.AntagPurchaseHistory;
+using Content.Shared.FixedPoint;
 using Content.Shared.Mind;
 using Content.Shared.Roles;
 using Content.Shared.Store;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Content.Server._White.AntagPurchaseHistory;
 
@@ -24,6 +27,7 @@ public sealed class AntagPurchaseHistorySystem : EntitySystem
         // StoreDiscountSystem removes exhausted modifiers from PurchasedItem. Snapshot Cost before that mutation.
         SubscribeLocalEvent<StoreBuyFinishedEvent>(OnBuyFinished, before: new[] { typeof(StoreDiscountSystem) });
         SubscribeLocalEvent<StoreRefundFinishedEvent>(OnRefundFinished);
+        SubscribeLocalEvent<AntagPurchaseHistoryComponent, ObjectivesTextGetAdditionalInfoEvent>(OnGetAdditionalInfo);
     }
 
     private void OnBuyFinished(ref StoreBuyFinishedEvent args)
@@ -61,5 +65,101 @@ public sealed class AntagPurchaseHistorySystem : EntitySystem
             if (purchase.StoreUid == args.StoreUid)
                 purchase.Refunded = true;
         }
+    }
+
+    private void OnGetAdditionalInfo(
+        EntityUid uid,
+        AntagPurchaseHistoryComponent component,
+        ref ObjectivesTextGetAdditionalInfoEvent args)
+    {
+        var markup = GetRoundEndMarkup(uid, component);
+        if (!string.IsNullOrEmpty(markup))
+            args.Lines.Add(markup);
+    }
+
+    /// <summary>
+    /// Builds the inline markup for all purchases that were not refunded.
+    /// Repeated purchases of the same listing at the same final price are grouped together.
+    /// </summary>
+    public string GetRoundEndMarkup(EntityUid mindUid, AntagPurchaseHistoryComponent? history = null)
+    {
+        if (!Resolve(mindUid, ref history, false))
+            return string.Empty;
+
+        var purchases = history.Purchases
+            .Where(purchase => !purchase.Refunded)
+            .ToList();
+
+        if (purchases.Count == 0)
+            return string.Empty;
+
+        var groupedPurchases = purchases
+            .GroupBy(purchase => (
+                purchase.ListingId,
+                FinalCost: AntagPurchaseMarkup.SerializeCost(purchase.FinalCost)))
+            .ToList();
+
+        var totalCost = new Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2>();
+        foreach (var purchase in purchases)
+        {
+            foreach (var (currency, amount) in purchase.FinalCost)
+                totalCost[currency] = totalCost.GetValueOrDefault(currency) + amount;
+        }
+
+        var message = new FormattedMessage();
+        message.AddText(Loc.GetString(
+            "antag-purchase-history-used",
+            ("amounts", GetPriceString(totalCost))));
+        message.AddText(" ");
+
+        for (var i = 0; i < groupedPurchases.Count; i++)
+        {
+            var group = groupedPurchases[i];
+            var purchase = group.First();
+
+            if (i > 0)
+                message.AddText(", ");
+
+            // The opening bracket must be escaped because this FormattedMessage is converted back to markup
+            // before it is parsed by the client.
+            message.AddText(FormattedMessage.EscapeText("["));
+            if (group.Count() > 1)
+                message.AddText($"{group.Count()}x ");
+
+            var attributes = new Dictionary<string, MarkupParameter>
+            {
+                [AntagPurchaseMarkup.FinalCostAttribute] = new(group.Key.FinalCost),
+                [AntagPurchaseMarkup.OriginalCostAttribute] = new(
+                    AntagPurchaseMarkup.SerializeCost(purchase.OriginalCost)),
+            };
+            message.PushTag(
+                new MarkupNode(
+                    AntagPurchaseMarkup.TagName,
+                    new MarkupParameter(purchase.ListingId.Id),
+                    attributes),
+                selfClosing: true);
+            message.AddText("]");
+        }
+
+        return message.ToMarkup();
+    }
+
+    private string GetPriceString(IReadOnlyDictionary<ProtoId<CurrencyPrototype>, FixedPoint2> cost)
+    {
+        if (cost.Count == 0)
+            return Loc.GetString("store-currency-free");
+
+        return string.Join(", ", cost
+            .OrderBy(pair => pair.Key.Id)
+            .Select(pair =>
+            {
+                if (!_prototypes.TryIndex(pair.Key, out CurrencyPrototype? currency))
+                    return $"{pair.Value} {pair.Key.Id}";
+
+                return Loc.GetString(
+                    "store-ui-price-display",
+                    ("amount", pair.Value),
+                    ("currency", Loc.GetString(currency.DisplayName, ("amount", pair.Value))));
+            }));
     }
 }

--- a/Content.Server/_White/AntagPurchaseHistory/AntagPurchaseHistorySystem.cs
+++ b/Content.Server/_White/AntagPurchaseHistory/AntagPurchaseHistorySystem.cs
@@ -39,12 +39,10 @@ public sealed class AntagPurchaseHistorySystem : EntitySystem
         }
 
         var listing = args.PurchasedItem;
-        var displayName = ListingLocalisationHelpers.GetLocalisedNameOrEntityName(listing, _prototypes);
         var history = EnsureComp<AntagPurchaseHistoryComponent>(mindUid);
 
         history.Purchases.Add(new AntagPurchaseRecord(
             listing.ID,
-            string.IsNullOrWhiteSpace(displayName) ? null : displayName,
             listing.Cost.ToDictionary(pair => pair.Key, pair => pair.Value),
             listing.OriginalCost.ToDictionary(pair => pair.Key, pair => pair.Value),
             args.StoreUid));

--- a/Content.Server/_White/AntagPurchaseHistory/AntagPurchaseHistorySystem.cs
+++ b/Content.Server/_White/AntagPurchaseHistory/AntagPurchaseHistorySystem.cs
@@ -1,0 +1,65 @@
+using System.Linq;
+using Content.Server.StoreDiscount.Systems;
+using Content.Shared._White.AntagPurchaseHistory;
+using Content.Shared.Mind;
+using Content.Shared.Roles;
+using Content.Shared.Store;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._White.AntagPurchaseHistory;
+
+/// <summary>
+/// Records successful store purchases made by antagonist minds.
+/// </summary>
+public sealed class AntagPurchaseHistorySystem : EntitySystem
+{
+    [Dependency] private readonly SharedMindSystem _mind = default!;
+    [Dependency] private readonly SharedRoleSystem _roles = default!;
+    [Dependency] private readonly IPrototypeManager _prototypes = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        // StoreDiscountSystem removes exhausted modifiers from PurchasedItem. Snapshot Cost before that mutation.
+        SubscribeLocalEvent<StoreBuyFinishedEvent>(OnBuyFinished, before: new[] { typeof(StoreDiscountSystem) });
+        SubscribeLocalEvent<StoreRefundFinishedEvent>(OnRefundFinished);
+    }
+
+    private void OnBuyFinished(ref StoreBuyFinishedEvent args)
+    {
+        if (!_mind.TryGetMind(args.Buyer, out var mindUid, out _) ||
+            !_roles.MindIsAntagonist(mindUid))
+        {
+            return;
+        }
+
+        var listing = args.PurchasedItem;
+        var displayName = ListingLocalisationHelpers.GetLocalisedNameOrEntityName(listing, _prototypes);
+        var history = EnsureComp<AntagPurchaseHistoryComponent>(mindUid);
+
+        history.Purchases.Add(new AntagPurchaseRecord(
+            listing.ID,
+            string.IsNullOrWhiteSpace(displayName) ? null : displayName,
+            listing.Cost.ToDictionary(pair => pair.Key, pair => pair.Value),
+            listing.OriginalCost.ToDictionary(pair => pair.Key, pair => pair.Value),
+            args.StoreUid));
+    }
+
+    private void OnRefundFinished(ref StoreRefundFinishedEvent args)
+    {
+        if (!_mind.TryGetMind(args.Buyer, out var mindUid, out _) ||
+            !TryComp<AntagPurchaseHistoryComponent>(mindUid, out var history))
+        {
+            return;
+        }
+
+        // StoreSystem refunds BoughtEntities and BalanceSpent in aggregate, without a per-listing mapping.
+        // Therefore every still-active purchase from this store is marked refunded together.
+        foreach (var purchase in history.Purchases)
+        {
+            if (purchase.StoreUid == args.StoreUid)
+                purchase.Refunded = true;
+        }
+    }
+}

--- a/Content.Shared/Store/StoreBuyFinishedEvent.cs
+++ b/Content.Shared/Store/StoreBuyFinishedEvent.cs
@@ -12,3 +12,14 @@ public readonly record struct StoreBuyFinishedEvent(
     EntityUid StoreUid,
     ListingDataWithCostModifiers PurchasedItem
 );
+
+// WD EDIT START - expose successful aggregate refunds to White purchase history.
+/// <summary>
+/// Raised after a store successfully refunds all purchases tracked in its current refund window.
+/// </summary>
+[ByRefEvent]
+public readonly record struct StoreRefundFinishedEvent(
+    EntityUid Buyer,
+    EntityUid StoreUid
+);
+// WD EDIT END

--- a/Content.Shared/_White/AntagPurchaseHistory/AntagPurchaseHistoryComponent.cs
+++ b/Content.Shared/_White/AntagPurchaseHistory/AntagPurchaseHistoryComponent.cs
@@ -23,9 +23,6 @@ public sealed class AntagPurchaseRecord
     public ProtoId<ListingPrototype> ListingId { get; }
 
     [ViewVariables(VVAccess.ReadOnly)]
-    public string? DisplayName { get; }
-
-    [ViewVariables(VVAccess.ReadOnly)]
     public Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2> FinalCost { get; }
 
     [ViewVariables(VVAccess.ReadOnly)]
@@ -39,13 +36,11 @@ public sealed class AntagPurchaseRecord
 
     public AntagPurchaseRecord(
         ProtoId<ListingPrototype> listingId,
-        string? displayName,
         Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2> finalCost,
         Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2> originalCost,
         EntityUid storeUid)
     {
         ListingId = listingId;
-        DisplayName = displayName;
         FinalCost = finalCost;
         OriginalCost = originalCost;
         StoreUid = storeUid;

--- a/Content.Shared/_White/AntagPurchaseHistory/AntagPurchaseHistoryComponent.cs
+++ b/Content.Shared/_White/AntagPurchaseHistory/AntagPurchaseHistoryComponent.cs
@@ -1,0 +1,53 @@
+using Content.Shared.FixedPoint;
+using Content.Shared.Store;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._White.AntagPurchaseHistory;
+
+/// <summary>
+/// Stores an antagonist's store purchase history on their mind entity.
+/// </summary>
+[RegisterComponent]
+public sealed partial class AntagPurchaseHistoryComponent : Component
+{
+    [ViewVariables]
+    public List<AntagPurchaseRecord> Purchases = new();
+}
+
+/// <summary>
+/// A snapshot of a store listing at the time it was purchased.
+/// </summary>
+public sealed class AntagPurchaseRecord
+{
+    [ViewVariables(VVAccess.ReadOnly)]
+    public ProtoId<ListingPrototype> ListingId { get; }
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    public string? DisplayName { get; }
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    public Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2> FinalCost { get; }
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    public Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2> OriginalCost { get; }
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    public EntityUid StoreUid { get; }
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    public bool Refunded { get; set; }
+
+    public AntagPurchaseRecord(
+        ProtoId<ListingPrototype> listingId,
+        string? displayName,
+        Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2> finalCost,
+        Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2> originalCost,
+        EntityUid storeUid)
+    {
+        ListingId = listingId;
+        DisplayName = displayName;
+        FinalCost = finalCost;
+        OriginalCost = originalCost;
+        StoreUid = storeUid;
+    }
+}

--- a/Content.Shared/_White/AntagPurchaseHistory/AntagPurchaseMarkup.cs
+++ b/Content.Shared/_White/AntagPurchaseHistory/AntagPurchaseMarkup.cs
@@ -1,0 +1,71 @@
+using System.Globalization;
+using System.Linq;
+using Content.Shared.FixedPoint;
+using Content.Shared.Store;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._White.AntagPurchaseHistory;
+
+/// <summary>
+/// Shared constants and serialization helpers for purchase icons embedded in round-end markup.
+/// </summary>
+public static class AntagPurchaseMarkup
+{
+    public const int IconSize = 24;
+    public const string TagName = "antagpurchase";
+    public const string FinalCostAttribute = "finalCost";
+    public const string OriginalCostAttribute = "originalCost";
+
+    public static string SerializeCost(IReadOnlyDictionary<ProtoId<CurrencyPrototype>, FixedPoint2> cost)
+    {
+        return string.Join(';', cost
+            .OrderBy(pair => pair.Key.Id)
+            .Select(pair => $"{pair.Key.Id}:{pair.Value.Value.ToString(CultureInfo.InvariantCulture)}"));
+    }
+
+    public static bool TryDeserializeCost(
+        string serialized,
+        out Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2> cost)
+    {
+        cost = new Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2>();
+        if (string.IsNullOrEmpty(serialized))
+            return true;
+
+        foreach (var entry in serialized.Split(';', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var separator = entry.LastIndexOf(':');
+            if (separator <= 0 || separator == entry.Length - 1 ||
+                !int.TryParse(
+                    entry[(separator + 1)..],
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out var cents))
+            {
+                cost.Clear();
+                return false;
+            }
+
+            var currency = new ProtoId<CurrencyPrototype>(entry[..separator]);
+            if (!cost.TryAdd(currency, FixedPoint2.FromCents(cents)))
+            {
+                cost.Clear();
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static bool HasDiscount(
+        IReadOnlyDictionary<ProtoId<CurrencyPrototype>, FixedPoint2> originalCost,
+        IReadOnlyDictionary<ProtoId<CurrencyPrototype>, FixedPoint2> finalCost)
+    {
+        foreach (var (currency, originalAmount) in originalCost)
+        {
+            if (!finalCost.TryGetValue(currency, out var finalAmount) || finalAmount < originalAmount)
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/Resources/Locale/en-US/_white/objectives/antag-purchase-history.ftl
+++ b/Resources/Locale/en-US/_white/objectives/antag-purchase-history.ftl
@@ -1,0 +1,1 @@
+antag-purchase-history-used = (Used { $amounts })

--- a/Resources/Locale/ru-RU/_white/objectives/antag-purchase-history.ftl
+++ b/Resources/Locale/ru-RU/_white/objectives/antag-purchase-history.ftl
@@ -1,0 +1,1 @@
+antag-purchase-history-used = (Потрачено { $amounts })


### PR DESCRIPTION
# Описание PR

В конце раунда в манифесте у антагонистов отображаются покупки и общая потраченная сумма валюты. Поддерживает скидки и возвраты. Группирует покупки по листингу и уплаченной цене.

---

# Медиа
<details><summary>Список</summary>
<p>
<img width="2560" height="1440" alt="2026-8-06_00 00 47" src="https://github.com/user-attachments/assets/de499cca-c0ab-491d-9c28-c26d8c5cd256" />
<img width="2560" height="1440" alt="2026-8-06_00 00 52" src="https://github.com/user-attachments/assets/0b510f46-39e3-4028-91a8-f7ee457e71e7" />
<img width="2560" height="1440" alt="2026-8-06_00 00 41" src="https://github.com/user-attachments/assets/49a670a1-b5ee-4857-a09d-61617e28a0c3" />
</p>
</details>

---

# Изменения

:cl: DEADISKO
- add: Список покупок антагониста в конце раунда
