### PR TITLE
Carry tweak

### DIFF
--- a/Content.Server/Carrying/CarryingSystem.cs
+++ b/Content.Server/Carrying/CarryingSystem.cs
@@ -97,7 +97,7 @@ namespace Content.Server.Carrying
         {
             // If the person is carrying someone, and the carried person is a pseudo-item, and the target entity is a storage,
             // then add an action to insert the carried entity into the target
-            var toInsert = args.Using;
+            EntityUid? toInsert = component.Carried; // WWDP EDIT
             if (toInsert is not { Valid: true } || !args.CanAccess
                 || !TryComp<PseudoItemComponent>(toInsert, out var pseudoItem)
                 || !TryComp<StorageComponent>(args.Target, out var storageComp)

--- a/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemSystem.cs
+++ b/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.Carrying;
+using Content.Server.Carrying;
 using Content.Server.DoAfter;
 using Content.Server.Item;
 using Content.Server.Popups;
@@ -61,15 +61,20 @@ public sealed class PseudoItemSystem : SharedPseudoItemSystem
 
     protected override void OnGettingPickedUpAttempt(EntityUid uid, PseudoItemComponent component, GettingPickedUpAttemptEvent args)
     {
-        // Try to pick the entity up instead first
-        if (args.User != args.Item && _carrying.TryCarry(args.User, uid))
-        {
-            args.Cancel();
-            return;
-        }
+        // WWDP EDIT START
+        // args.Cancel();
+        // return;
 
-        // If could not pick up, just take it out onto the ground as per default
-        base.OnGettingPickedUpAttempt(uid, component, args);
+        // // Try to pick the entity up instead first
+        // if (args.User != args.Item && _carrying.TryCarry(args.User, uid))
+        // {
+        args.Cancel();
+        //     return;
+        // }
+
+        // // If could not pick up, just take it out onto the ground as per default
+        // base.OnGettingPickedUpAttempt(uid, component, args);
+        // WWDP EDIT END
     }
 
     // Show a popup when a pseudo-item falls asleep inside a bag.

--- a/Content.Shared/Nyanotrasen/Item/PseudoItem/SharedPseudoItemSystem.cs
+++ b/Content.Shared/Nyanotrasen/Item/PseudoItem/SharedPseudoItemSystem.cs
@@ -117,17 +117,29 @@ public abstract partial class SharedPseudoItemSystem : EntitySystem
     protected virtual void OnGettingPickedUpAttempt(EntityUid uid, PseudoItemComponent component,
         GettingPickedUpAttemptEvent args)
     {
-        if (args.User == args.Item)
-            return;
+        // WWDP EDIT START
+        // if (args.User == args.Item)
+        //     return;
 
-        Transform(uid).AttachToGridOrMap();
+        // Transform(uid).AttachToGridOrMap();
+        // WWDP EDIT END
         args.Cancel();
     }
 
     private void OnDropAttempt(EntityUid uid, PseudoItemComponent component, DropAttemptEvent args)
     {
-        if (component.Active)
+        // WWDP EDIT START
+        // if (component.Active)
+        //     args.Cancel();
+        if (!component.Active)
+            return;
+        var parent = Transform(uid).ParentUid;
+        if (!TryComp<StorageComponent>(parent, out var storage) || !_storage.HasSpace((parent, storage)))
+        {
+            _popupSystem.PopupEntity(Loc.GetString("popup-pseudo-item-no-space"), uid);
             args.Cancel();
+        }
+        // WWDP EDIT END
     }
 
     private void OnInsertAttempt(EntityUid uid, PseudoItemComponent component,
@@ -135,8 +147,10 @@ public abstract partial class SharedPseudoItemSystem : EntitySystem
     {
         if (!component.Active)
             return;
-        // This hopefully shouldn't trigger, but this is a failsafe just in case so we dont bluespace them cats
-        args.Cancel();
+        // WWDP EDIT START
+        // // This hopefully shouldn't trigger, but this is a failsafe just in case so we dont bluespace them cats
+        // args.Cancel();
+        // WWDP EDIT END
     }
 
     // Prevents moving within the bag :)

--- a/Content.Shared/Nyanotrasen/Item/PseudoItem/SharedPseudoItemSystem.cs
+++ b/Content.Shared/Nyanotrasen/Item/PseudoItem/SharedPseudoItemSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.Actions;
 using Content.Shared.Bed.Sleep;
 using Content.Shared.DoAfter;
 using Content.Shared.Hands;
+using Content.Shared.Hands.Components; // WWDP EDIT
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Item;
@@ -134,7 +135,17 @@ public abstract partial class SharedPseudoItemSystem : EntitySystem
         if (!component.Active)
             return;
         var parent = Transform(uid).ParentUid;
-        if (!TryComp<StorageComponent>(parent, out var storage) || !_storage.HasSpace((parent, storage)))
+        if (!TryComp<StorageComponent>(parent, out var storage))
+        {
+            args.Cancel();
+            return;
+        }
+        if (!TryComp<HandsComponent>(uid, out var hands) || hands.ActiveHandEntity is not { } held)
+        {
+            args.Cancel();
+            return;
+        }
+        if (!_storage.CanInsert(parent, held, out _, storage))
         {
             _popupSystem.PopupEntity(Loc.GetString("popup-pseudo-item-no-space"), uid);
             args.Cancel();

--- a/Resources/Locale/en-US/_white/nyanotrasen/item/pseudoitem/pseudoitem.ftl
+++ b/Resources/Locale/en-US/_white/nyanotrasen/item/pseudoitem/pseudoitem.ftl
@@ -1,0 +1,1 @@
+popup-pseudo-item-no-space = No space.

--- a/Resources/Locale/ru-RU/_white/nyanotrasen/item/pseudoitem/pseudoitem.ftl
+++ b/Resources/Locale/ru-RU/_white/nyanotrasen/item/pseudoitem/pseudoitem.ftl
@@ -1,0 +1,1 @@
+popup-pseudo-item-no-space = Нет места.


### PR DESCRIPTION
# Описание PR

Теперь снова можно класть лёгких Уристов в вещмешок, взяв их в руки и воспользовавшись контекстным меню.

Выбрасывание предметов, будучи в вещмешке, теперь допустимо, если места для предмета хватает (может повлиять на неинициализированные пространства, которые используются, как пример, в капсуле криосна).

Вынуть Уриста из вещмешка теперь невозможно просто кликнув по нему, предотвращая нежеланное «выпадение» из контейнера.

Быстрые клавиши умной складки инвентаря теперь доступны для использования для тех, кто находится в вещмешке. Это также исправляет проблему некоторой работы контейнеров в контейнере.

Добавлен попап «нет места», если при попытки выкинуть предмет, находясь в вещмешке, места для предмета не хватает.

---

# Изменения

:cl: Myaflic
- tweak: Слегка изменена система контейнеров.
