### PR TITLE
ACO faster

### DIFF
--- a/Content.Shared/DeltaV/CCVars/DCCVars.cs
+++ b/Content.Shared/DeltaV/CCVars/DCCVars.cs
@@ -46,7 +46,7 @@ public sealed class DCCVars
     /// How long with no captain before requesting an ACO be elected.
     /// </summary>
     public static readonly CVarDef<TimeSpan> RequestAcoDelay =
-        CVarDef.Create("game.request_aco_delay", TimeSpan.FromMinutes(15), CVar.SERVERONLY | CVar.ARCHIVE);
+        CVarDef.Create("game.request_aco_delay", TimeSpan.FromMinutes(1), CVar.SERVERONLY | CVar.ARCHIVE); // WWDP EDIT 15 --> 1
 
     /// <summary>
     /// Determines whether an ACO should be requested when the captain leaves during the round,


### PR DESCRIPTION
# Описание PR

В текущих реалях билда, когда на сменах нет инженеров и командования, а свет на многих картах иссякает в первые десять минут, предлагаю сделать открытие шкафчика капитана спустя шесть минут с начала смены (одна минута до проверки, есть ли капитан и ещё пять минут до открытия запасной айди). Ранее это время было аж двадцать минут в сумме, что очень даже много и за это время все давно успевали сломать этот шкафчик, или даже саму каюту капитана.

Думаю я всё сказал. Можете задавать вопросы.

---

# Изменения

:cl: Myaflic
- tweak: Запаска открывается спустя шесть минут отсутствия капитана.
